### PR TITLE
feat(models): complete model hierarchy v0.3.x

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -14,8 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        experimental: [false]
+        include:
+          - python-version: "3.14"
+            experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
     - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Toolbox to manage localized messages with json and gettext functions."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "i18n-tools"
-version = "0.0.1"
+version = "0.3.0"
 authors = [
     { name = "biface" }
 ]
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "ndict-tools>=0.6.0",
+    "ndict-tools>=1.2.0",
     "babel"
 ]
 

--- a/src/i18n_tools/__init__.py
+++ b/src/i18n_tools/__init__.py
@@ -9,6 +9,10 @@ redistributing this file, you agree to comply with the terms of this license.
 
 **Author(s):**
 This module is authored and maintained as part of the i18n-tools package.
+
+References
+----------
+- biface/i18n#48 : public API __init__.py (DD-21, DD-22, DD-23)
 """
 
 from i18n_tools.__static__ import (
@@ -16,11 +20,39 @@ from i18n_tools.__static__ import (
     I18N_TOOLS_LOCALE,
     I18N_TOOLS_MODULE_NAME,
     I18N_TOOLS_ROOT_NAME,
+    I18N_TOOLS_TRANSLATION_FILE_EXT,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 __all__ = [
-    I18N_TOOLS_MODULE_NAME,
-    I18N_TOOLS_ROOT_NAME,
+    # Models — exposed after __version__ is defined to avoid circular import
+    # (corpus.py imports __version__ from this module)
+    "Message",
+    "Book",
+    "Corpus",
+    "FallbackBook",
+    "Encyclopaedia",
+    # Configuration
+    "Repository",
+    # Constants
+    "I18N_TOOLS_CONFIG",
+    "I18N_TOOLS_LOCALE",
+    "I18N_TOOLS_MODULE_NAME",
+    "I18N_TOOLS_ROOT_NAME",
+    "I18N_TOOLS_TRANSLATION_FILE_EXT",
+    # Version
+    "__version__",
 ]
+
+# Models imported after __version__ is defined to avoid circular import:
+# corpus.py → from i18n_tools import __version__
+# Refactoring deferred to v0.4.x (DD-19, biface/i18n#47)
+from i18n_tools.models import (  # noqa: E402
+    Book,
+    Corpus,
+    Encyclopaedia,
+    FallbackBook,
+    Message,
+)
+from i18n_tools.models.repository import Repository  # noqa: E402

--- a/src/i18n_tools/exceptions.py
+++ b/src/i18n_tools/exceptions.py
@@ -1,0 +1,51 @@
+"""
+Exceptions Module
+=================
+
+Project-specific exception hierarchy for i18n-tools (DD-24).
+
+All exceptions inherit from ``I18nToolsError``, which allows callers
+to catch any package error with a single ``except I18nToolsError`` clause,
+or to target a specific subclass for fine-grained handling.
+
+**License:**
+This file is distributed under the terms of the CeCILL-C Free Software
+License Agreement. By using, modifying, or redistributing this file,
+you agree to comply with the terms of this license.
+"""
+
+
+class I18nToolsError(Exception):
+    """Base class for all i18n-tools exceptions."""
+
+
+class FormatError(I18nToolsError):
+    """Raised when a .i18t file has an invalid or unexpected structure."""
+
+
+class MessageError(I18nToolsError):
+    """Raised when an operation on a Message object fails."""
+
+
+class MessageNotFoundError(MessageError):
+    """Raised when a message identifier cannot be found in any Book of the fallback chain."""
+
+
+class BookError(I18nToolsError):
+    """Raised when an operation on a Book object fails."""
+
+
+class RepositoryError(I18nToolsError):
+    """Raised when a configuration or repository operation fails."""
+
+
+class LoaderError(I18nToolsError):
+    """Raised when a file I/O operation in the loaders layer fails."""
+
+
+class ConversionError(I18nToolsError):
+    """Raised when a format conversion (e.g. Babel Catalog ↔ Book) fails."""
+
+
+class LocaleError(I18nToolsError):
+    """Raised when an IETF language tag is invalid or cannot be normalised."""

--- a/src/i18n_tools/loaders/handler.py
+++ b/src/i18n_tools/loaders/handler.py
@@ -187,7 +187,7 @@ def create_template(
             msgid_bugs_address=repository[["details", "report-bugs-to"]],
             fuzzy=(
                 bool(repository[["details", "flags", "fuzzy"]])
-                if ["details", "flags", "fuzzy"] in repository.dict_paths()
+                if ["details", "flags", "fuzzy"] in repository.paths()
                 else True
             ),
         )

--- a/src/i18n_tools/loaders/loader.py
+++ b/src/i18n_tools/loaders/loader.py
@@ -22,6 +22,7 @@ from i18n_tools.loaders.utils import (
     _create_gzip,
     _detect_format,
     _load_json,
+    _save_by_format,
     _save_json,
 )
 
@@ -178,6 +179,45 @@ def load_book(file_path: str) -> Dict[str, Any]:
             continue
         result[msgid] = {"messages": matrix, "metadata": {}}
     return result
+
+
+def save_book(book: Any, file_path: str) -> None:
+    """
+    Serialize a Book to a .i18t file.
+
+    The serialisation format (JSON or YAML) is detected from the file
+    extension. The structure written to disk follows the native .i18t format::
+
+        {
+            "metadata": { ... },
+            "<msgid>": { "messages": [...], "metadata": { ... } },
+            ...
+        }
+
+    :param book: The Book instance to persist.
+    :type book: Book
+    :param file_path: Full path (directory + filename) of the target .i18t file.
+    :type file_path: str
+    :raises FileNotFoundError: If the parent directory does not exist.
+
+    References
+    ----------
+    - biface/i18n#42 : strict separation models / loaders (DD-06)
+    - biface/i18n#46 : loader ↔ models bridge and native serialisation (DD-15, DD-16)
+    - biface/i18n#56 : .i18t naming convention and format detection (DD-34)
+    - biface/i18n#57 : Book.save() persistence
+    """
+    from i18n_tools.converter import message_to_i18n_tools_format
+
+    fmt = _detect_format(file_path)
+    data: Dict[str, Any] = {"metadata": book.metadata.to_dict()}
+    for msg in book.messages.values():
+        # load_locale_json / check_json_integrity expect each entry to be
+        # the raw messages matrix (a list of lists), not the full
+        # {"messages": ..., "metadata": ...} dict produced by
+        # message_to_i18n_tools_format.  We extract only the "messages" key.
+        data[msg.id] = message_to_i18n_tools_format(msg)["messages"]
+    _save_by_format(file_path, data, fmt)
 
 
 def aggregate_locale_json(

--- a/src/i18n_tools/models/__init__.py
+++ b/src/i18n_tools/models/__init__.py
@@ -1,2 +1,2 @@
-from .corpus import Corpus, Message
+from .corpus import Book, Corpus, Encyclopaedia, FallbackBook, Message
 from .repository import Repository

--- a/src/i18n_tools/models/corpus.py
+++ b/src/i18n_tools/models/corpus.py
@@ -176,12 +176,12 @@ class Message:
         __check = True
 
         if isinstance(value, StrictNestedDictionary):
-            paths = value.dict_paths()
+            paths = value.paths()
         else:
-            paths = StrictNestedDictionary(value).dict_paths()
+            paths = StrictNestedDictionary(value).paths()
 
         for path in paths:
-            if not path in self.metadata.dict_paths():
+            if not path in self.metadata.paths():
                 __check = False
 
         return __check
@@ -1123,7 +1123,7 @@ class Message:
         self._assert_valid_option(option)
         if index is None:
             self._remove_options_segment(option)
-        elif self.options_plurals.dict_paths().__contains__([option, index]):
+        elif self.options_plurals.paths().__contains__([option, index]):
             del self.options_plurals[[option, index]]
             reshaped_dict: Dict[int, str] = {}
             for idx, key in enumerate(
@@ -1179,7 +1179,7 @@ class Message:
             return self.metadata
 
         if (isinstance(key, str) and key in self.metadata) or (
-            isinstance(key, list) and key in self.metadata.dict_paths()
+            isinstance(key, list) and key in self.metadata.paths()
         ):
             return self.metadata[key]
 
@@ -1235,11 +1235,9 @@ class Message:
         if args:
             for path, value in args:
                 if (
-                    isinstance(path, str)
-                    and self.metadata.dict_paths().__contains__([path])
+                    isinstance(path, str) and self.metadata.paths().__contains__([path])
                 ) or (
-                    isinstance(path, list)
-                    and self.metadata.dict_paths().__contains__(path)
+                    isinstance(path, list) and self.metadata.paths().__contains__(path)
                 ):
                     self.metadata[path] = value
                 else:
@@ -1257,7 +1255,7 @@ class Message:
                 if isinstance(value, dict):
                     for sub_key, sub_value in value.items():
                         path = [key, sub_key]
-                        if not self.metadata.dict_paths().__contains__(path):
+                        if not self.metadata.paths().__contains__(path):
                             raise KeyError(
                                 f"The path '{path}' is not a present key in the metadata dictionary"
                             )
@@ -1282,11 +1280,9 @@ class Message:
         if args:
             for path, value in args:
                 if (
-                    isinstance(path, str)
-                    and self.metadata.dict_paths().__contains__([path])
+                    isinstance(path, str) and self.metadata.paths().__contains__([path])
                 ) or (
-                    isinstance(path, list)
-                    and self.metadata.dict_paths().__contains__(path)
+                    isinstance(path, list) and self.metadata.paths().__contains__(path)
                 ):
                     if self.metadata[path] == value:
                         raise ValueError(
@@ -1308,7 +1304,7 @@ class Message:
                 if isinstance(value, dict):
                     for sub_key, sub_value in value.items():
                         path = [key, sub_key]
-                        if not self.metadata.dict_paths().__contains__(path):
+                        if not self.metadata.paths().__contains__(path):
                             raise KeyError(
                                 f"The path '{path}' is not a present key in the metadata dictionary"
                             )
@@ -1346,7 +1342,7 @@ class Message:
 
         if key is None:
             self.metadata = ref_meta
-        elif isinstance(key, list) and key not in self.metadata.dict_paths():
+        elif isinstance(key, list) and key not in self.metadata.paths():
             raise KeyError(
                 f"path '{key}' is not a present key in the metadata dictionary"
             )
@@ -1983,13 +1979,13 @@ class Book:
         if value is None:
             # delete/reset
             if isinstance(key, list):
-                if key not in self.metadata.dict_paths():
+                if key not in self.metadata.paths():
                     raise KeyError(
                         f"The path '{key}' is not a present key in the metadata dictionary"
                     )
                 # If we know a default for that path, use it, otherwise remove by setting empty value
                 self.metadata[key] = (
-                    default_meta[key] if key in default_meta.dict_paths() else None
+                    default_meta[key] if key in default_meta.paths() else None
                 )
             elif isinstance(key, str):
                 if not self.metadata.is_key(key):
@@ -2004,7 +2000,7 @@ class Book:
         else:
             # add/update
             if isinstance(key, list):
-                if key not in self.metadata.dict_paths():
+                if key not in self.metadata.paths():
                     # allow creating nested metadata path only for 'statistics'
                     # otherwise require existing path
                     raise KeyError(
@@ -2113,76 +2109,404 @@ class Book:
 
     def save(self, path_directory: str) -> None:
         """
-        This function save the content of the Book in a file
-        :param path_directory: the named directory where the file book is saved
+        Save the content of this Book to a .i18t file.
+
+        The file is written at ``path_directory/self.filename``.
+        Delegates all I/O to ``save_book()`` in ``loader.py``,
+        following the same delegation pattern as ``load()``.
+
+        :param path_directory: Directory where the .i18t file will be written.
         :type path_directory: str
-        :return: nothing
-        :rtype: None
+        :raises FileNotFoundError: If ``path_directory`` does not exist.
+
+        References
+        ----------
+        - biface/i18n#42 : strict separation models / loaders (DD-06)
+        - biface/i18n#57 : Book.save() persistence (DD-06, DD-15, DD-16)
         """
-        tmp_dict = {"metadata": self.metadata.to_dict()}
-        for msg in self.messages.values():
-            tmp_dict[msg.id] = msg.to_i18n_tools_format()
+        from i18n_tools.loaders.loader import save_book as _save_book
+
+        file_path = path_directory + "/" + self.filename
+        _save_book(self, file_path)
+
+
+class FallbackBook:
+    """
+    Transparent proxy over an ordered list of Books implementing the fallback chain.
+
+    ``FallbackBook`` is never instantiated directly by the user — it is constructed
+    by ``Corpus.get_book()`` from the chain of available Books that match the
+    requested language (DD-09b).
+
+    For each ``get_message()`` call the chain is walked in order; the first Book
+    that contains the requested identifier wins.  If no Book in the chain holds
+    the identifier, ``MessageNotFoundError`` is raised.
+
+    The column fallback (DD-27) is orthogonal: it operates inside a single
+    ``Message`` object and is handled by ``formatter.publish()``.
+
+    References
+    ----------
+    - biface/i18n#43 : Corpus / FallbackBook proxy design (DD-09, DD-09b)
+    - biface/i18n#20 : MessageNotFoundError (DD-24)
+    """
+
+    def __init__(self, chain: List["Book"], language: str) -> None:
+        """
+        Initialise the FallbackBook from an ordered list of real Books.
+
+        :param chain: Ordered list of Books to consult, from most specific to
+            least specific language.  Must not be empty.
+        :type chain: List[Book]
+        :param language: The requested language tag (first in the chain).
+        :type language: str
+        :raises ValueError: If ``chain`` is empty.
+        """
+        if not chain:
+            raise ValueError("FallbackBook chain must contain at least one Book")
+        self._chain: List["Book"] = chain
+        self._language: str = language
+
+    # --- Core message access ---
+
+    def get_message(self, msg_id: str) -> Message:
+        """
+        Return the first Message matching ``msg_id`` found in the fallback chain.
+
+        :param msg_id: Identifier of the message to retrieve.
+        :type msg_id: str
+        :return: The first matching Message.
+        :rtype: Message
+        :raises MessageNotFoundError: If no Book in the chain contains ``msg_id``.
+
+        References
+        ----------
+        - biface/i18n#43 : FallbackBook chain resolution (DD-09b)
+        - biface/i18n#20 : MessageNotFoundError (DD-24)
+        """
+        from i18n_tools.exceptions import MessageNotFoundError
+
+        for book in self._chain:
+            msg = book.get(msg_id)
+            if msg is not None:
+                return msg
+        raise MessageNotFoundError(
+            f"Message '{msg_id}' not found in fallback chain {[b.language for b in self._chain]}"
+        )
+
+    # --- Book-compatible interface ---
+
+    @property
+    def language(self) -> str:
+        """The requested language — first language in the fallback chain."""
+        return self._language
+
+    @property
+    def domain(self) -> str:
+        """Domain of the first Book in the chain."""
+        return self._chain[0].domain
+
+    def __iter__(self):
+        """Iterate over Message instances of the first Book in the chain."""
+        return iter(self._chain[0])
+
+    def __len__(self) -> int:
+        """Number of messages in the first Book of the chain."""
+        return len(self._chain[0].messages)
+
+    def __contains__(self, msg_id: str) -> bool:
+        """Return True if ``msg_id`` exists in any Book of the chain."""
+        return any(book.get(msg_id) is not None for book in self._chain)
+
+    def __repr__(self) -> str:
+        langs = [b.language for b in self._chain]
+        return f"FallbackBook(language='{self._language}', chain={langs})"
 
 
 class Corpus:
     """
-    A class for handling corpora as a collection of books in a single domain.
+    Container of Books for a single domain across all loaded languages.
 
-    This class manages multiple books of internationalization messages within a single domain.
+    ``Corpus`` holds one real ``Book`` per available language.  Its central
+    entry point is ``get_book(lang)``, which returns a ``FallbackBook`` — a
+    transparent proxy that resolves each message individually through the
+    fallback chain (DD-09).
 
-    Attributes:
-        repository (StrictNestedDictionary): The repository containing all messages.
-        messages (Dict[str, Message]): A dictionary of messages in this corpus.
+    The fallback chain for a requested language ``lang`` is built inline
+    (v0.3.x, no ``fallback.py`` yet) using the IETF parent tag extracted via
+    ``langcodes``.  The full ``fallback.py`` module (DD-29) will replace this
+    inline resolution in v1.0.0.
+
+    Cross-language operations
+    -------------------------
+    - ``coverage()``  — coverage rate per language (0.0–1.0)
+    - ``missing(lang)`` — identifiers absent in ``lang`` but present elsewhere
+    - ``languages``   — list of loaded languages
+
+    References
+    ----------
+    - biface/i18n#43 : Corpus design (DD-09, DD-09b)
+    - biface/i18n#20 : MessageNotFoundError (DD-24)
     """
 
-    def __init__(
-        self,
-        repository: Optional[StrictNestedDictionary] = None,
-        messages: Optional[List[Message]] = None,
-    ):
+    def __init__(self, domain: str) -> None:
         """
-        Initialize a new Corpus instance.
+        Initialise an empty Corpus for the given domain.
 
-        Args:
-            repository (Optional[StrictNestedDictionary], optional): The repository containing translations. Defaults to None.
-            messages (Optional[List[Message]], optional): List of messages to add to the corpus. Defaults to None.
-        """
-        self.repository = (
-            repository if repository is not None else StrictNestedDictionary()
-        )
-        self.messages: Dict[str, Message] = {}
-        if messages is not None:
-            for message in messages:
-                self.messages[message.id] = message
+        :param domain: The translation domain this Corpus covers.
+        :type domain: str
+        :raises TypeError: If ``domain`` is not a string.
 
-    def add_repository(self, repository: StrictNestedDictionary) -> None:
+        References
+        ----------
+        - biface/i18n#43 : Corpus design (DD-09)
         """
-        Add a repository to the corpus.
+        if not isinstance(domain, str):
+            raise TypeError(f"Corpus domain must be a string, got {type(domain)}")
+        self._domain: str = domain
+        self._books: Dict[str, "Book"] = {}  # language -> Book
 
-        Args:
-            repository (StrictNestedDictionary): The repository to add to the corpus.
-        """
-        self.repository = repository
+    # --- Book management ---
 
-    def add_message(self, message: Message) -> None:
+    def add_book(self, book: "Book") -> None:
         """
-        Add a message to the corpus.
+        Register a real Book in this Corpus.
 
-        Args:
-            message (Message): The message to add to the corpus.
+        :param book: A fully populated Book whose domain matches this Corpus.
+        :type book: Book
+        :raises TypeError: If ``book`` is not a Book instance.
+        :raises ValueError: If the Book domain does not match the Corpus domain,
+            or if a Book for that language is already registered.
+
+        References
+        ----------
+        - biface/i18n#43 : Corpus design (DD-09)
         """
-        self.messages[message.id] = message
+        if not isinstance(book, Book):
+            raise TypeError(f"Expected a Book instance, got {type(book)}")
+        if book.domain != self._domain:
+            raise ValueError(
+                f"Book domain '{book.domain}' does not match Corpus domain '{self._domain}'"
+            )
+        if book.language in self._books:
+            raise ValueError(
+                f"A Book for language '{book.language}' is already registered in this Corpus"
+            )
+        self._books[book.language] = book
+
+    def get_book(self, lang: str) -> FallbackBook:
+        """
+        Return a FallbackBook for ``lang`` built from the inline fallback chain.
+
+        Chain resolution (v0.3.x inline, DD-29 pending for v1.0.0):
+        1. The requested language (``lang``) if loaded.
+        2. The IETF parent tag (e.g. ``fr`` for ``fr-CH``) if different and loaded.
+        3. Any other loaded language whose IETF parent matches (siblings).
+        4. All remaining loaded languages in insertion order.
+
+        If the resulting chain is empty, ``MessageNotFoundError`` is raised.
+
+        :param lang: Requested language tag (e.g. ``"fr-CH"``).
+        :type lang: str
+        :return: A FallbackBook wrapping the resolved chain.
+        :rtype: FallbackBook
+        :raises MessageNotFoundError: If no loaded Book matches the chain.
+
+        References
+        ----------
+        - biface/i18n#43 : Corpus / FallbackBook (DD-09, DD-09b)
+        - biface/i18n#52 : fallback.py deferred to v1.0.0 (DD-29)
+        """
+        from i18n_tools.exceptions import MessageNotFoundError
+
+        normalized = normalize_language_tag(lang)
+        chain: List["Book"] = []
+        seen: set = set()
+
+        def _add(language: str) -> None:
+            if language not in seen and language in self._books:
+                chain.append(self._books[language])
+                seen.add(language)
+
+        # 1. Requested language
+        _add(normalized)
+
+        # 2. IETF parent (e.g. "fr" for "fr-CH" or "fr-FR")
+        parent = normalized.rsplit("-", 1)[0] if "-" in normalized else None
+        if parent:
+            _add(parent)
+
+        # 3. Siblings — other loaded languages sharing the same parent
+        for loaded_lang in self._books:
+            loaded_parent = (
+                loaded_lang.rsplit("-", 1)[0] if "-" in loaded_lang else loaded_lang
+            )
+            if loaded_parent == parent or loaded_lang == parent:
+                _add(loaded_lang)
+
+        # 4. All remaining loaded languages
+        for loaded_lang in self._books:
+            _add(loaded_lang)
+
+        if not chain:
+            raise MessageNotFoundError(
+                f"No Book available in Corpus '{self._domain}' for language '{lang}'"
+            )
+
+        return FallbackBook(chain, normalized)
+
+    # --- Cross-language operations ---
+
+    @property
+    def domain(self) -> str:
+        """The domain this Corpus covers."""
+        return self._domain
+
+    @property
+    def languages(self) -> List[str]:
+        """List of loaded language tags, in insertion order."""
+        return list(self._books.keys())
+
+    def coverage(self) -> Dict[str, float]:
+        """
+        Compute the coverage rate of each loaded language.
+
+        The reference set is the union of all message identifiers across all
+        loaded Books.  Coverage for a language is the fraction of reference
+        identifiers present in its Book.
+
+        :return: Mapping of language tag to coverage rate (0.0–1.0).
+            Returns an empty dict if no Books are loaded.
+        :rtype: Dict[str, float]
+
+        References
+        ----------
+        - biface/i18n#43 : Corpus cross-language operations (DD-09)
+        """
+        if not self._books:
+            return {}
+        all_ids: set = set()
+        for book in self._books.values():
+            all_ids.update(book.messages.keys())
+        total = len(all_ids)
+        if total == 0:
+            return {lang: 1.0 for lang in self._books}
+        return {
+            lang: len(set(book.messages.keys()) & all_ids) / total
+            for lang, book in self._books.items()
+        }
+
+    def missing(self, lang: str) -> List[str]:
+        """
+        Return identifiers present in other Books but absent in ``lang``.
+
+        :param lang: Language tag to check.
+        :type lang: str
+        :return: Sorted list of missing message identifiers.
+        :rtype: List[str]
+        :raises ValueError: If ``lang`` is not loaded in this Corpus.
+
+        References
+        ----------
+        - biface/i18n#43 : Corpus cross-language operations (DD-09)
+        """
+        normalized = normalize_language_tag(lang)
+        if normalized not in self._books:
+            raise ValueError(
+                f"Language '{normalized}' is not loaded in Corpus '{self._domain}'"
+            )
+        all_ids: set = set()
+        for book in self._books.values():
+            all_ids.update(book.messages.keys())
+        present = set(self._books[normalized].messages.keys())
+        return sorted(all_ids - present)
+
+    def __repr__(self) -> str:
+        return f"Corpus(domain='{self._domain}', languages={self.languages})"
 
 
 class Encyclopaedia:
     """
-    A class for handling libraries as a collection of Corpus objects.
+    Collection of Corpora across all domains and modules of a repository.
 
-    This class manages multiple Corpus objects, providing a comprehensive collection
-    of internationalization messages across different domains.
+    ``Encyclopaedia`` is keyed by ``(module, domain)`` pairs (DD-07).  Corpora
+    are loaded lazily: a ``Corpus`` is inserted via ``add_corpus()`` and
+    retrieved via ``get_corpus()``.  The lazy-loading hook (loading from disk
+    on first access) is reserved for v1.0.0 once ``core.py`` is in place.
 
-    Attributes:
-        corpora (Dict[str, Corpus]): A dictionary of Corpus objects in this encyclopaedia.
+    References
+    ----------
+    - biface/i18n#42 : four-level model hierarchy (DD-07)
     """
 
-    pass
+    def __init__(self) -> None:
+        """
+        Initialise an empty Encyclopaedia.
+
+        References
+        ----------
+        - biface/i18n#42 : four-level model hierarchy (DD-07)
+        """
+        # Key: (module, domain) -> Corpus
+        self._corpora: Dict[Tuple[str, str], Corpus] = {}
+
+    def add_corpus(self, module: str, corpus: Corpus) -> None:
+        """
+        Register a Corpus under ``(module, corpus.domain)``.
+
+        :param module: Module identifier (e.g. ``"src/app"``).
+        :type module: str
+        :param corpus: Corpus to register.
+        :type corpus: Corpus
+        :raises TypeError: If ``module`` is not a string or ``corpus`` is not a Corpus.
+        :raises ValueError: If a Corpus is already registered for ``(module, domain)``.
+
+        References
+        ----------
+        - biface/i18n#42 : four-level model hierarchy (DD-07)
+        """
+        if not isinstance(module, str):
+            raise TypeError(f"module must be a string, got {type(module)}")
+        if not isinstance(corpus, Corpus):
+            raise TypeError(f"Expected a Corpus instance, got {type(corpus)}")
+        key = (module, corpus.domain)
+        if key in self._corpora:
+            raise ValueError(
+                f"A Corpus for module='{module}', domain='{corpus.domain}' is already registered"
+            )
+        self._corpora[key] = corpus
+
+    def get_corpus(self, module: str, domain: str) -> Corpus:
+        """
+        Retrieve the Corpus for ``(module, domain)``.
+
+        :param module: Module identifier.
+        :type module: str
+        :param domain: Domain name.
+        :type domain: str
+        :return: The registered Corpus.
+        :rtype: Corpus
+        :raises KeyError: If no Corpus is registered for ``(module, domain)``.
+
+        References
+        ----------
+        - biface/i18n#42 : four-level model hierarchy (DD-07)
+        """
+        key = (module, domain)
+        if key not in self._corpora:
+            raise KeyError(
+                f"No Corpus registered for module='{module}', domain='{domain}'"
+            )
+        return self._corpora[key]
+
+    def __contains__(self, key: Tuple[str, str]) -> bool:
+        """Return True if ``(module, domain)`` is registered."""
+        return key in self._corpora
+
+    def __len__(self) -> int:
+        """Number of registered Corpora."""
+        return len(self._corpora)
+
+    def __repr__(self) -> str:
+        keys = list(self._corpora.keys())
+        return f"Encyclopaedia(corpora={keys})"

--- a/src/i18n_tools/models/repository.py
+++ b/src/i18n_tools/models/repository.py
@@ -356,7 +356,7 @@ class Repository(StrictNestedDictionary):
 
     def _apply_args(self, args) -> None:
         for path, value in args:
-            if not (isinstance(path, list) and path in self.dict_paths()) and not (
+            if not (isinstance(path, list) and path in self.paths()) and not (
                 isinstance(path, str) and self.is_key(path)
             ):
                 raise KeyError(f"{path} is not a valid path or key")
@@ -879,7 +879,7 @@ class Repository(StrictNestedDictionary):
         :raises ValueError: If the value already exist in the repository or the parameter is empty.
         """
 
-        if not self.dict_paths().__contains__(path):
+        if not self.paths().__contains__(path):
             raise KeyError(f"Path '{path}' does not exist in the repository.")
 
         if type(value) != type(self[path]):
@@ -906,7 +906,7 @@ class Repository(StrictNestedDictionary):
         :raises TypeError: If the value type differs from the existing value type.
         :raises ValueError: If the current value is empty (use add_value instead).
         """
-        if not self.dict_paths().__contains__(path):
+        if not self.paths().__contains__(path):
             raise KeyError(f"Path '{path}' does not exist in the repository.")
 
         if type(value) != type(self[path]):
@@ -934,7 +934,7 @@ class Repository(StrictNestedDictionary):
         :raises KeyError: If the path does not exist in the repository.
         :raises ValueError: If the value is already empty.
         """
-        if not self.dict_paths().__contains__(path):
+        if not self.paths().__contains__(path):
             raise KeyError(f"Path '{path}' does not exist in the repository.")
 
         current = self[path]
@@ -974,7 +974,7 @@ class Repository(StrictNestedDictionary):
         :rtype: None
         :raises KeyError: If the path does not exist in the repository.
         """
-        if not self.dict_paths().__contains__(path):
+        if not self.paths().__contains__(path):
             raise KeyError(f"Path '{path}' does not exist in the repository.")
 
         current = self[path]

--- a/tests/02_models/conftest.py
+++ b/tests/02_models/conftest.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from helpers import copy_and_update_repository
 
+from i18n_tools import __version__
 from i18n_tools.models import Message as MessageModel
 from i18n_tools.models.corpus import Book, Message
 
@@ -23,7 +24,7 @@ def fr_message():
             2: {1: "Bonjour Messieurs", 2: "Messieurs"},
         },
         metadata={
-            "version": "0.1.0",
+            "version": __version__,
             "language": "fr-FR",
             "location": [],
             "flags": ["python-format"],
@@ -49,7 +50,7 @@ def en_message():
             2: {1: "Hi everyone", 2: "Gentlemen"},
         },
         metadata={
-            "version": "0.1.0",
+            "version": __version__,
             "language": "en",
             "location": [],
             "flags": ["python-format"],
@@ -104,7 +105,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -140,7 +141,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -175,7 +176,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -211,7 +212,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -248,7 +249,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -284,7 +285,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -319,7 +320,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -355,7 +356,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -389,7 +390,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -425,7 +426,7 @@ def fr_fr_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "fr-FR",
                 "location": [],
                 "flags": ["python-format"],
@@ -467,7 +468,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -503,7 +504,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -538,7 +539,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -574,7 +575,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -609,7 +610,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -645,7 +646,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -680,7 +681,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -716,7 +717,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -748,7 +749,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -784,7 +785,7 @@ def en_us_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-US",
                 "location": [],
                 "flags": ["python-format"],
@@ -826,7 +827,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -862,7 +863,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -897,7 +898,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -933,7 +934,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -968,7 +969,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -1004,7 +1005,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -1039,7 +1040,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -1075,7 +1076,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -1107,7 +1108,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -1143,7 +1144,7 @@ def en_gb_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en-GB",
                 "location": [],
                 "flags": ["python-format"],
@@ -1185,7 +1186,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1221,7 +1222,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1256,7 +1257,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1292,7 +1293,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1329,7 +1330,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1365,7 +1366,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1400,7 +1401,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1436,7 +1437,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1473,7 +1474,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],
@@ -1509,7 +1510,7 @@ def it_it_messages():
                 },
             },
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "it-IT",
                 "location": [],
                 "flags": ["python-format"],

--- a/tests/02_models/test_00_message.py
+++ b/tests/02_models/test_00_message.py
@@ -360,7 +360,7 @@ class TestMessageGetMetadata:
             (
                 "fr_message",
                 {
-                    "version": "0.1.0",
+                    "version": __version__,
                     "language": "fr-FR",
                     "location": [],
                     "flags": ["python-format"],
@@ -372,7 +372,7 @@ class TestMessageGetMetadata:
             (
                 "empty_message",
                 {
-                    "version": "0.1.0",
+                    "version": __version__,
                     "language": "",
                     "location": [],
                     "flags": ["python-format"],
@@ -384,7 +384,7 @@ class TestMessageGetMetadata:
             (
                 "en_message",
                 {
-                    "version": "0.1.0",
+                    "version": __version__,
                     "language": "en",
                     "location": [],
                     "flags": ["python-format"],
@@ -403,19 +403,19 @@ class TestMessageGetMetadata:
     @pytest.mark.parametrize(
         "fixture_name, path, expected",
         [
-            ("fr_message", "version", "0.1.0"),
+            ("fr_message", "version", __version__),
             ("fr_message", "language", "fr-FR"),
             ("fr_message", "flags", ["python-format"]),
             ("fr_message", "count", {"singular": 3, "plurals": [2, 2, 2]}),
             ("fr_message", ["count", "singular"], 3),
             ("fr_message", ["count", "plurals"], [2, 2, 2]),
-            ("empty_message", "version", "0.1.0"),
+            ("empty_message", "version", __version__),
             ("empty_message", "language", ""),
             ("empty_message", "flags", ["python-format"]),
             ("empty_message", "count", {"singular": 0, "plurals": [0]}),
             ("empty_message", ["count", "singular"], 0),
             ("empty_message", ["count", "plurals"], [0]),
-            ("en_message", "version", "0.1.0"),
+            ("en_message", "version", __version__),
             ("en_message", "language", "en"),
             ("en_message", "flags", ["python-format"]),
             ("en_message", "count", {"singular": 3, "plurals": [2, 2, 2]}),
@@ -2388,7 +2388,7 @@ class TestMessageUpdateMetadata:
                 [],
                 {"location": [("file.txt", 126)], "language": "en-GB"},
                 {
-                    "version": "0.1.0",
+                    "version": __version__,
                     "language": "en-GB",
                     "location": [("file.txt", 126)],
                     "flags": ["python-format"],
@@ -2405,7 +2405,7 @@ class TestMessageUpdateMetadata:
                 [[["location"], [("file.txt", 126)]], [["language"], "en-GB"]],
                 {},
                 {
-                    "version": "0.1.0",
+                    "version": __version__,
                     "language": "en-GB",
                     "location": [("file.txt", 126)],
                     "flags": ["python-format"],
@@ -2476,12 +2476,12 @@ class TestMessageUpdateMetadata:
             (
                 (),
                 {
-                    "version": "0.1.0",
+                    "version": __version__,
                     "language": "fr-FR",
                     "location": [("file.py", 132)],
                     "user_comments": ["A test for metadata"],
                 },
-                "The value (0.1.0) is already stored in the path '[version]'",
+                f"The value ({__version__}) is already stored in the path '[version]'",
             ),
             (
                 [],
@@ -3234,7 +3234,7 @@ class TestMessageFormat:
                         ["Bonjour tout le monde", "Mesdames", "Messieurs"],
                     ],
                     "metadata": {
-                        "version": "0.1.0",
+                        "version": __version__,
                         "language": "fr-FR",
                         "locations": [],
                         "flags": ["python-format"],
@@ -3256,7 +3256,7 @@ class TestMessageFormat:
                         ["Hi everyone", "Ladies", "Gentlemen"],
                     ],
                     "metadata": {
-                        "version": "0.1.0",
+                        "version": __version__,
                         "language": "en",
                         "locations": [],
                         "flags": ["python-format"],
@@ -3285,7 +3285,7 @@ class TestMessageFormat:
                         ["Bonjour tout le monde", "Mesdames", "Messieurs"],
                     ],
                     "metadata": {
-                        "version": "0.1.0",
+                        "version": __version__,
                         "locations": [],
                         "flags": ["python-format"],
                         "user_comments": [
@@ -3306,7 +3306,7 @@ class TestMessageFormat:
                         ["Hi everyone", "Ladies", "Gentlemen"],
                     ],
                     "metadata": {
-                        "version": "0.1.0",
+                        "version": __version__,
                         "locations": [],
                         "flags": ["python-format"],
                         "user_comments": ["Greeting message to one or more..."],
@@ -3325,7 +3325,7 @@ class TestMessageFormat:
                         ["Bonjour tout le monde", "Mesdames", "Messieurs"],
                     ],
                     "metadata": {
-                        "version": "0.1.0",
+                        "version": __version__,
                         "language": "fr-FR",
                         "locations": [],
                         "flags": ["python-format"],
@@ -3351,7 +3351,7 @@ class TestMessageFormat:
                         ["Hi everyone", "Ladies", "Gentlemen"],
                     ],
                     "metadata": {
-                        "version": "0.1.0",
+                        "version": __version__,
                         "language": "en",
                         "locations": [],
                         "flags": ["python-format"],
@@ -3448,7 +3448,7 @@ class TestMessageEquality:
             options_plurals={1: {1: "Hi {name}s"}},
             context="greet",
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en",
                 "location": [],
                 "flags": ["python-format"],
@@ -3464,7 +3464,7 @@ class TestMessageEquality:
             options_plurals={1: {1: "Hi {name}s"}},
             context="greet",
             metadata={
-                "version": "0.1.0",
+                "version": __version__,
                 "language": "en",
                 "location": [],
                 "flags": ["python-format"],
@@ -3607,7 +3607,7 @@ class TestMessageCreation:
     )
     def test_metadata_version(self, fixture_name, request):
         message = request.getfixturevalue(fixture_name)
-        assert message.metadata["version"] == "0.1.0"
+        assert message.metadata["version"] == __version__
 
     @pytest.mark.parametrize(
         "fixture_name, expect",

--- a/tests/02_models/test_01_book.py
+++ b/tests/02_models/test_01_book.py
@@ -7,6 +7,7 @@ import re
 
 import pytest
 
+from i18n_tools import __version__
 from i18n_tools.converter import message_to_i18n_tools_format
 from i18n_tools.models.corpus import Book, Message
 
@@ -31,7 +32,7 @@ def _make_simple_message(lang: str) -> Message:
         default_plurals={1: "Hello worlds"},
         options_plurals={1: {1: "Hello {who}s"}},
         metadata={
-            "version": "0.1.0",
+            "version": __version__,
             "language": lang,
             "location": [],
             "flags": ["python-format"],
@@ -210,7 +211,7 @@ class TestBookAdd:
                             },
                         },
                         metadata={
-                            "version": "0.1.0",
+                            "version": __version__,
                             "language": "fr-FR",
                             "location": [],
                             "flags": ["python-format"],
@@ -246,7 +247,7 @@ class TestBookAdd:
                             },
                         },
                         metadata={
-                            "version": "0.1.0",
+                            "version": __version__,
                             "language": "fr-FR",
                             "location": [],
                             "flags": ["python-format"],
@@ -352,7 +353,7 @@ class TestBookAdd:
                             },
                         },
                         metadata={
-                            "version": "0.1.0",
+                            "version": __version__,
                             "language": "fr-BE",
                             "location": [],
                             "flags": ["python-format"],
@@ -395,7 +396,7 @@ class TestBookAdd:
                             },
                         },
                         metadata={
-                            "version": "0.1.0",
+                            "version": __version__,
                             "language": "fr-FR",
                             "location": [],
                             "flags": ["python-format"],
@@ -466,10 +467,10 @@ class TestBookMetadata:
         assert book.metadata.get("language_team", None) == ""
         assert book.metadata.get("header_comment", None) == ""
         # Statistics exist and initialized or computed
-        assert book.metadata.dict_paths().__contains__(
+        assert book.metadata.paths().__contains__(
             ["statistics", "total_messages"]
         ) and isinstance(book.metadata[["statistics", "total_messages"]], int)
-        assert book.metadata.dict_paths().__contains__(
+        assert book.metadata.paths().__contains__(
             ["statistics", "total_words"]
         ) and isinstance(book.metadata[["statistics", "total_words"]], int)
         # Count backward compatibility
@@ -669,5 +670,43 @@ class TestBookLoad:
 
 
 class TestBookSave:
-    def test_save(self, fr_fr_book):
-        fr_fr_book.save("tmp")
+    def test_save(self, fr_fr_book, tmp_path):
+        """Book.save() writes a readable .i18t file (round-trip check).
+
+        References
+        ----------
+        - biface/i18n#57 : Book.save() persistence (DD-06, DD-15, DD-16)
+        """
+        fr_fr_book.save(str(tmp_path))
+        saved_file = tmp_path / fr_fr_book.filename
+        assert saved_file.exists()
+
+    def test_save_file_not_found(self, fr_fr_book):
+        """Book.save() raises FileNotFoundError if the directory does not exist.
+
+        References
+        ----------
+        - biface/i18n#57 : Book.save() persistence
+        """
+        with pytest.raises(FileNotFoundError):
+            fr_fr_book.save("/nonexistent/directory")
+
+    def test_save_round_trip(self, fr_fr_book, tmp_path):
+        """load() after save() produces a Book with the same message ids.
+
+        References
+        ----------
+        - biface/i18n#57 : Book.save() persistence (DD-06, DD-15, DD-16)
+        """
+        from i18n_tools.models.corpus import Book
+
+        fr_fr_book.save(str(tmp_path))
+
+        reloaded = Book(
+            domain=fr_fr_book.domain,
+            language=fr_fr_book.language,
+            format=fr_fr_book.format,
+        )
+        reloaded.load(str(tmp_path))
+
+        assert set(reloaded.messages.keys()) == set(fr_fr_book.messages.keys())

--- a/tests/02_models/test_02_corpus.py
+++ b/tests/02_models/test_02_corpus.py
@@ -1,0 +1,344 @@
+"""
+Tests for Corpus, FallbackBook and Encyclopaedia (DD-09, DD-09b, DD-07).
+
+References
+----------
+- biface/i18n#43 : Corpus / FallbackBook design (DD-09, DD-09b)
+- biface/i18n#42 : four-level model hierarchy (DD-07)
+- biface/i18n#20 : MessageNotFoundError (DD-24)
+"""
+
+import pytest
+
+from i18n_tools.exceptions import MessageNotFoundError
+from i18n_tools.models.corpus import Book, Corpus, Encyclopaedia, FallbackBook
+
+# ---------------------------------------------------------------------------
+# TestCorpusInit
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusInit:
+    """Corpus initialisation and basic properties."""
+
+    def test_init_with_domain(self):
+        corpus = Corpus(domain="test")
+        assert corpus.domain == "test"
+        assert corpus.languages == []
+
+    def test_init_wrong_type_raises(self):
+        with pytest.raises(TypeError):
+            Corpus(domain=42)
+
+    def test_repr(self):
+        corpus = Corpus(domain="test")
+        assert "test" in repr(corpus)
+
+
+# ---------------------------------------------------------------------------
+# TestCorpusAddBook
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusAddBook:
+    """Corpus.add_book() — registration and error cases."""
+
+    def test_add_book_registers_language(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        assert "fr-FR" in corpus.languages
+
+    def test_add_multiple_books(self, fr_fr_book, en_us_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        corpus.add_book(en_us_book)
+        assert set(corpus.languages) == {"fr-FR", "en-US"}
+
+    def test_add_book_wrong_type_raises(self):
+        corpus = Corpus(domain="test")
+        with pytest.raises(TypeError):
+            corpus.add_book("not a book")
+
+    def test_add_book_wrong_domain_raises(self, fr_fr_book):
+        corpus = Corpus(domain="other_domain")
+        with pytest.raises(ValueError, match="domain"):
+            corpus.add_book(fr_fr_book)
+
+    def test_add_duplicate_language_raises(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        with pytest.raises(ValueError, match="already registered"):
+            corpus.add_book(fr_fr_book)
+
+
+# ---------------------------------------------------------------------------
+# TestCorpusGetBook
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusGetBook:
+    """Corpus.get_book() — FallbackBook construction and chain resolution."""
+
+    def test_get_exact_language(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        fb = corpus.get_book("fr-FR")
+        assert isinstance(fb, FallbackBook)
+        assert fb.language == "fr-FR"
+
+    def test_get_book_fallback_to_parent(self, fr_fr_book):
+        """fr-CH not loaded — should fall back to fr-FR (same IETF parent 'fr')."""
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        fb = corpus.get_book("fr-CH")
+        assert isinstance(fb, FallbackBook)
+        assert fb.language == "fr-CH"
+        # fr-FR must be in the chain
+        assert any(b.language == "fr-FR" for b in fb._chain)
+
+    def test_get_book_no_match_raises(self):
+        """Requesting any language from an empty Corpus raises MessageNotFoundError."""
+        corpus = Corpus(domain="test")
+        with pytest.raises(MessageNotFoundError):
+            corpus.get_book("de-DE")
+
+    def test_get_book_empty_corpus_raises(self):
+        corpus = Corpus(domain="test")
+        with pytest.raises(MessageNotFoundError):
+            corpus.get_book("fr-FR")
+
+    def test_get_book_returns_fallback_book(self, fr_fr_book, en_us_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        corpus.add_book(en_us_book)
+        fb = corpus.get_book("fr-FR")
+        assert isinstance(fb, FallbackBook)
+
+
+# ---------------------------------------------------------------------------
+# TestCorpusCoverage
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusCoverage:
+    """Corpus.coverage() — coverage rate per language."""
+
+    def test_full_coverage(self, fr_fr_book, en_us_book):
+        """Both books have the same ids → coverage 1.0 each."""
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        corpus.add_book(en_us_book)
+        cov = corpus.coverage()
+        assert cov["fr-FR"] == pytest.approx(1.0)
+        assert cov["en-US"] == pytest.approx(1.0)
+
+    def test_empty_corpus_returns_empty(self):
+        corpus = Corpus(domain="test")
+        assert corpus.coverage() == {}
+
+    def test_single_book_full_coverage(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        cov = corpus.coverage()
+        assert cov["fr-FR"] == pytest.approx(1.0)
+
+    def test_partial_coverage(self, fr_fr_book, en_us_book, fr_fr_messages):
+        """A book with a subset of ids has coverage < 1.0."""
+        # Build a partial en-US book with only 5 of the 10 messages
+        partial_ids = list(fr_fr_messages.keys())[:5]
+        partial_messages = [
+            msg for mid, msg in fr_fr_messages.items() if mid in partial_ids
+        ]
+        # Create a partial fr-FR-like book in en-US (reuse en_us_book fixture msgs)
+        en_us_msg_list = list(en_us_book.messages.values())
+        partial_book = Book(*en_us_msg_list[:5], domain="test", language="en-US")
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        corpus.add_book(partial_book)
+        cov = corpus.coverage()
+        assert cov["fr-FR"] == pytest.approx(1.0)
+        assert cov["en-US"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# TestCorpusMissing
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusMissing:
+    """Corpus.missing() — identifiers absent in a given language."""
+
+    def test_no_missing_when_full(self, fr_fr_book, en_us_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        corpus.add_book(en_us_book)
+        assert corpus.missing("fr-FR") == []
+        assert corpus.missing("en-US") == []
+
+    def test_missing_returns_sorted_ids(self, fr_fr_book, en_us_book):
+        """Partial en-US book → missing returns sorted list of absent ids."""
+        en_us_msg_list = list(en_us_book.messages.values())
+        partial_book = Book(*en_us_msg_list[:5], domain="test", language="en-US")
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        corpus.add_book(partial_book)
+        missing = corpus.missing("en-US")
+        assert missing == sorted(missing)
+        assert len(missing) == 5
+
+    def test_missing_unknown_language_raises(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        with pytest.raises(ValueError, match="not loaded"):
+            corpus.missing("de-DE")
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackBookInit
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackBookInit:
+    """FallbackBook initialisation."""
+
+    def test_init_single_book(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        assert fb.language == "fr-FR"
+        assert fb.domain == "test"
+
+    def test_init_empty_chain_raises(self):
+        with pytest.raises(ValueError, match="at least one Book"):
+            FallbackBook([], "fr-FR")
+
+    def test_len(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        assert len(fb) == len(fr_fr_book.messages)
+
+    def test_contains_existing_id(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        assert "1100" in fb
+
+    def test_contains_missing_id(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        assert "9999" not in fb
+
+    def test_iter_yields_messages(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        messages = list(fb)
+        assert len(messages) == len(fr_fr_book.messages)
+
+    def test_repr(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        assert "fr-FR" in repr(fb)
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackBookGetMessage
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackBookGetMessage:
+    """FallbackBook.get_message() — chain resolution per message."""
+
+    def test_get_message_from_first_book(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        msg = fb.get_message("1100")
+        assert msg.id == "1100"
+
+    def test_get_message_falls_back_to_second_book(self, fr_fr_book, en_us_book):
+        """Chain [partial_fr, en_us]: id absent in partial_fr is found in en_us."""
+        # Build a partial fr-FR book missing "1109"
+        fr_msgs = list(fr_fr_book.messages.values())
+        partial_fr = Book(*fr_msgs[:-1], domain="test", language="fr-FR")
+        fb = FallbackBook([partial_fr, en_us_book], "fr-FR")
+        msg = fb.get_message("1109")
+        # Must come from en_us_book since partial_fr doesn't have it
+        assert msg.id == "1109"
+        assert msg.metadata["language"] == "en-US"
+
+    def test_get_message_not_found_raises(self, fr_fr_book):
+        fb = FallbackBook([fr_fr_book], "fr-FR")
+        with pytest.raises(MessageNotFoundError, match="9999"):
+            fb.get_message("9999")
+
+    def test_get_message_prefers_first_in_chain(self, fr_fr_book, en_us_book):
+        """id present in both books → first book wins."""
+        fb = FallbackBook([fr_fr_book, en_us_book], "fr-FR")
+        msg = fb.get_message("1100")
+        assert msg.metadata["language"] == "fr-FR"
+
+
+# ---------------------------------------------------------------------------
+# TestEncyclopaediaInit
+# ---------------------------------------------------------------------------
+
+
+class TestEncyclopaediaInit:
+    """Encyclopaedia initialisation."""
+
+    def test_init_empty(self):
+        enc = Encyclopaedia()
+        assert len(enc) == 0
+
+    def test_repr(self):
+        enc = Encyclopaedia()
+        assert "Encyclopaedia" in repr(enc)
+
+
+# ---------------------------------------------------------------------------
+# TestEncyclopaediaAddGet
+# ---------------------------------------------------------------------------
+
+
+class TestEncyclopaediaAddGet:
+    """Encyclopaedia.add_corpus() and get_corpus()."""
+
+    def test_add_and_get_corpus(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        enc = Encyclopaedia()
+        enc.add_corpus("src/app", corpus)
+        retrieved = enc.get_corpus("src/app", "test")
+        assert retrieved is corpus
+
+    def test_contains(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        enc = Encyclopaedia()
+        enc.add_corpus("src/app", corpus)
+        assert ("src/app", "test") in enc
+        assert ("src/app", "other") not in enc
+
+    def test_add_wrong_type_module_raises(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        enc = Encyclopaedia()
+        with pytest.raises(TypeError):
+            enc.add_corpus(42, corpus)
+
+    def test_add_wrong_type_corpus_raises(self):
+        enc = Encyclopaedia()
+        with pytest.raises(TypeError):
+            enc.add_corpus("src/app", "not a corpus")
+
+    def test_add_duplicate_raises(self, fr_fr_book):
+        corpus = Corpus(domain="test")
+        corpus.add_book(fr_fr_book)
+        enc = Encyclopaedia()
+        enc.add_corpus("src/app", corpus)
+        with pytest.raises(ValueError, match="already registered"):
+            enc.add_corpus("src/app", corpus)
+
+    def test_get_nonexistent_raises(self):
+        enc = Encyclopaedia()
+        with pytest.raises(KeyError):
+            enc.get_corpus("src/app", "test")
+
+    def test_len(self, fr_fr_book, en_us_book):
+        corpus1 = Corpus(domain="test")
+        corpus1.add_book(fr_fr_book)
+        corpus2 = Corpus(domain="test")
+        corpus2.add_book(en_us_book)
+        enc = Encyclopaedia()
+        enc.add_corpus("src/app", corpus1)
+        enc.add_corpus("src/other", corpus2)
+        assert len(enc) == 2


### PR DESCRIPTION
## Summary

Implements the complete model hierarchy for v0.3.x milestone:
- Exception hierarchy (`exceptions.py`)
- `Book.save()` persistence via `save_book()` delegation
- `Corpus`, `FallbackBook`, `Encyclopaedia` classes
- Complete public API in `__init__.py`
- ndict-tools 1.2.0 migration (`dict_paths()` → `paths()`)
- Python >=3.10 constraint aligned with ndict-tools>=1.2.0

## Type of change

- [x] New feature (non-breaking change adding functionality)
- [x] Chore (dependency update, tooling)

## Related issues

Closes #18, #19, #20, #23, #48, #57

## List of changes

- `src/i18n_tools/exceptions.py` — new exception hierarchy (DD-24)
- `src/i18n_tools/models/corpus.py` — `Corpus`, `FallbackBook`, `Encyclopaedia`, `Book.save()` (DD-07, DD-09, DD-09b)
- `src/i18n_tools/loaders/loader.py` — `save_book()` (DD-06, DD-15, DD-16, DD-34)
- `src/i18n_tools/models/__init__.py` — complete model exports (DD-23)
- `src/i18n_tools/__init__.py` — public API, fix `__all__` typo (DD-21)
- `src/i18n_tools/loaders/handler.py` — `dict_paths()` → `paths()`
- `src/i18n_tools/models/repository.py` — `dict_paths()` → `paths()`
- `pyproject.toml` — version 0.3.0, ndict-tools>=1.2.0, requires-python>=3.10
- `.github/workflows/python-ci.yaml` — drop 3.9, add 3.13/3.14
- `tests/02_models/test_02_corpus.py` — new test suite (DD-07, DD-09, DD-09b)
- `tests/02_models/conftest.py`, `test_00_message.py`, `test_01_book.py` — `__version__` fixes

## Testing

- Baseline: 1007 passed / 41 skipped → now 1037+ passed / 41 skipped / 0 failed
- `tox -e local` and `tox -e local-ci` green on `fr_FR.UTF-8` and `en_US.UTF-8`

## Notes

- `Config` not yet exposed in `__init__.py` — circular import deferred to v0.4.x (DD-19)
- `fallback.py` inline resolution only — full `fallback.py` module deferred to v1.0.0 (DD-29)