### PR TITLE
v0.4.0 — Quality, coverage & documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,173 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Sections per [CONVENTIONS.md](CONVENTIONS.md) §7 (Releases).
+
+Issue/PR references use the GitHub issue number from `biface/i18n`.
+
+---
+
+## [Unreleased] — v0.4.x — Quality, coverage & documentation
+
+### 🐛 Bug Fixes
+- `Repository.add_value()`: the guard `value is not None or not value` was a
+  tautology (always `True` for any input) — `add_value()` could never
+  succeed on its intended use case (an empty path) and silently overwrote
+  any already-set value, including with `None`/`""`. (#29)
+- `loader.load_book()`: never called `_detect_format()`, always loaded via
+  `_load_json()` regardless of the file's actual extension — a
+  `.yaml.i18t` file was silently parsed as JSON. (#67)
+- `loader.py::_save_po` (dead code, removed) carried a regression of a bug
+  already fixed once in v0.1.x (#8): opened its target file in read mode
+  then attempted to write to it.
+- `loaders/utils.py`: 11 functions masked every failure (malformed
+  JSON/YAML/TOML, permission errors, etc.) as `FileNotFoundError`. Specific,
+  actionable exceptions now propagate naturally. (#26)
+- `loaders/utils.py::_load_config_file`: accepted `.yml` as a valid
+  extension but had no branch to handle it, silently returning `None`. (#26)
+- `loaders/handler.py::_verify_target_domain`: raised `IndexError` for a
+  missing domain while its own docstring promised `ValueError`; the
+  module-not-registered case was re-wrapped, losing the original
+  traceback. Realigned to raise `ValueError` consistently, propagating the
+  module error naturally instead of masking it. (#27)
+- `sync.py::check_repository`: `.pot` files were created once per
+  *language* inside `LC_MESSAGES/` instead of once per *domain* in
+  `templates/` (DD-12). (#30)
+
+### 🔧 Maintenance
+- Resolved the circular import between `i18n_tools.__init__` and three
+  internal modules (`models/corpus.py`, `loaders/handler.py`,
+  `loaders/repository.py`); `__version__` now lives in `__static__.py`.
+  `Config` is exposed in the public API for the first time. (#64)
+- `models/corpus.py` (`Book`) no longer imports `loaders.utils` directly
+  (DD-06); format resolution now goes through `loader.build_book_filename()`.
+  Also fixes an inconsistency where the constructor accepted invalid
+  formats silently while `add_format()`/`update_format()` did not. (#66)
+- `loaders/loader.py`: removed 9 dead functions (6 private + 3 public
+  PO/POT/MO wrappers), fully redundant with `utils.py`/`handler.py`. (#67)
+- `models/repository.py`: extracted duplicated type-dispatch logic from
+  `remove_value()`/`clean_value()` into `_empty_value_for()`. (#28)
+- `loaders/handler.py`: removed 12 no-value `try/except Exception as e:
+  raise e` wrappers (DD-26); removed the dead stub `dump_catalog()`
+  (duplicate of `update_catalog()`, never called or tested). (#27, #68)
+- `loaders/utils.py::_check_domains`: removed the same no-value
+  `except ValueError as e: raise e` pattern. (#26)
+- `pyproject.toml`: fixed `[project.urls]` pointing to `biface/ndt`
+  instead of `biface/i18n`; removed duplicate unconstrained
+  `ndict-tools` dependency entries in tox environments. (#63)
+
+### 🧪 Tests
+- `loaders/loader.py` coverage: 43% → 100% (`load_locale_json`,
+  `aggregate_locale_json`, `save_locale_json`,
+  `save_aggregated_locale_json` had no direct test before). Loaders layer
+  overall: 87% → 94%. (#31)
+- First tests for `sync.py` (`check_repository`) — none existed before. (#30)
+- First direct tests for `Repository.add_value`/`update_value`/
+  `remove_value`/`clean_value`. (#29)
+
+### 📚 Documentation
+- Corrected DD-19: `loaders/repository.py` is live, tested code (archive
+  and aggregation operations with no equivalent elsewhere) — not the dead
+  legacy loader the decision assumed without inspection. (#65)
+- Split the bilingual `README.md` into separate `README.md` (EN) and
+  `README.fr.md` (FR), refreshed the roadmap to reflect `v0.3.x` as
+  delivered and added the `v0.5.x`/`v0.6.x`/`v0.7.x` milestones.
+- `LICENSE.md` described `ndict-tools` instead of `i18n-tools` (copy-paste
+  leftover); corrected, then split into `license.md` (EN) / `licence.md`
+  (FR), matching the README split.
+- Same correction applied to `CODE_OF_CONDUCT.md` / `CODE_DE_CONDUITE.md`
+  (referenced `ndict-tools`).
+
+---
+
+## v0.3.x — Complete model hierarchy (2026-05-31)
+
+### ✨ New Features
+- `Corpus` fixed; `FallbackBook` implemented — transparent multi-language
+  fallback resolution (DD-09, DD-09b). (#18)
+- `Encyclopaedia` implemented with lazy corpus loading. (#19)
+- `exceptions.py` — `I18nToolsError` hierarchy (DD-24). (#20)
+- Complete public API exposed in `src/i18n_tools/__init__.py` (DD-21). (#22)
+- `Book.save()` — model-to-disk persistence (DD-06, DD-15). (#57)
+
+### 🐛 Bug Fixes
+- Test suite failed on `master` under an English locale (`LANG=en`);
+  `api.py` error messages were locale-dependent. (#59)
+
+### 🔧 Maintenance
+- `models/__init__.py`: added missing `Book` and `Encyclopaedia` exports. (#21)
+- Test infrastructure audited and reorganised (numbered directories,
+  nested `conftest.py`, network/timeout markers). (#32)
+
+### 🧪 Tests
+- `Corpus`, `Encyclopaedia`, `FallbackBook`. (#23)
+- `Repository` — construction, defaults, CRUD methods. (#24)
+
+### 📐 Design Decisions Recorded
+- DD-09/DD-09b — `FallbackBook` proxy for multi-language resolution. (#43)
+- DD-21/DD-22/DD-23 — Public API: `__init__.py`, loaders boundary, models
+  exports. (#48)
+- DD-24/DD-25/DD-26 — Exception hierarchy and error handling policy. (#49)
+- DD-35 — `api.py` language policy and test assertion strategy. (#60)
+
+---
+
+## v0.2.x — Loader ↔ model bridge (2026-05-03)
+
+### ✨ New Features
+- `load_book()` implemented in `loader.py` — the central loader ↔ model
+  bridge. (#16)
+- `_detect_format()` added to `loaders/utils.py` (DD-34). (#56)
+
+### 🐛 Bug Fixes
+- `loaders/repository.py` ignored the `.i18t` extension (2 FIXMEs). (#13)
+- `update_catalog()` was commented out — `.po` files were never synced
+  after JSON changes. (#14)
+
+### 🔧 Maintenance
+- `aggregate_dictionaries()`: fixed wrong output filename and metadata
+  key. (#15)
+
+### 📐 Design Decisions Recorded
+- DD-10/DD-11/DD-12 — `.i18t` format: extension, internal structure,
+  repository layout. (#44)
+- DD-13/DD-14/DD-14b — External dependencies: Babel, langcodes,
+  ndict-tools. (#45)
+- DD-15/DD-16 — Hub-and-spoke conversion architecture, native
+  serialisation. (#46)
+- DD-18/DD-19/DD-20 — `Config` Singleton, `Repository` migration, CRUD
+  API. (#47)
+- DD-34 — `.i18t` naming convention and format detection. (#55)
+
+---
+
+## v0.1.x — Foundational cleanup (2026-03-24)
+
+### 🐛 Bug Fixes
+- Typo `__ALL__` → `__all__` in package `__init__.py`. (#6)
+- `Corpus.__init__`: `self.messages` was never initialized. (#7)
+- `_save_po` opened its target file in read mode (`'r'`) instead of write
+  mode (`'w'`). (#8)
+- `create_template` compared the `fuzzy` flag to the string `'True'`
+  instead of a boolean. (#9)
+- `formatter.publish()` called a non-existent `Message.format()` — stub
+  implemented with column fallback. (#12)
+
+### 🔧 Maintenance
+- Reserved field `plural_rule = None` added to `Message` and `Book`. (#10)
+- Removed 10 leftover debug `print()` calls from production code. (#11)
+
+### 📐 Design Decisions Recorded
+- DD-02/DD-03 — `messages[row][col]` matrix structure, free plurals. (#40)
+- DD-05/DD-06 — Layered architecture, strict model/layer separation. (#41)
+- DD-07/DD-08 — Four-level model hierarchy, `Book` as atomic persistence
+  unit. (#42)
+
+---
+
+## Custom format (2026-03-14)
+
+Initial exploration phase: evaluating translation file formats before
+settling on the native, object-oriented `.i18t` design that the project
+has used ever since.

--- a/CODE_DE_CONDUITE.md
+++ b/CODE_DE_CONDUITE.md
@@ -1,0 +1,45 @@
+# Code de Conduite
+
+**[English version available](CODE_OF_CONDUCT.md)**
+
+## Portée
+
+Ce code de conduite s'applique à toute personne qui participe au projet **i18n-tools** ou
+qui s'exprime publiquement à son sujet — dans le dépôt GitHub, les issues, les pull
+requests, les discussions, et dans tout espace public où i18n-tools est le sujet.
+
+## Ce que nous attendons
+
+- Être respectueux. Le désaccord est normal ; le mépris ne l'est pas.
+- Critiquer les idées, pas les personnes.
+- Être précis. Les critiques vagues n'aident personne.
+- Si vous ne comprenez pas quelque chose, posez la question. Si vous savez quelque
+  chose, partagez-le.
+
+## Ce qui n'est pas acceptable
+
+- Les attaques personnelles, les insultes ou les remarques dégradantes envers les
+  contributeurs.
+- Le harcèlement sous quelque forme que ce soit, en public ou en privé.
+- Rejeter des contributions sans explication.
+- Perturber délibérément les discussions.
+
+## Signalement
+
+Si vous êtes témoin ou victime d'un comportement contraire à ce code de conduite,
+signalez-le en privé au mainteneur. Les signalements sont traités de manière
+confidentielle.
+
+Contact : email privé — adresse disponible dans `pyproject.toml` ou sur le profil
+GitHub du mainteneur ([github.com/biface](https://github.com/biface)).
+
+## Mesures
+
+Le mainteneur examinera les signalements et pourra supprimer des commentaires, fermer
+des issues, ou exclure des contributeurs qui violent ce code de conduite de manière
+répétée ou grave.
+
+## Base
+
+Ce code de conduite est adapté du
+[Code de Conduite Rust](https://www.rust-lang.org/fr/policies/code-of-conduct).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+**[Version française disponible](CODE_DE_CONDUITE.md)**
+
+## Scope
+
+This code of conduct applies to anyone who participates in the **i18n-tools** project
+or who speaks publicly about it — in the GitHub repository, in issues, in pull requests,
+in discussions, and in any public space where i18n-tools is a subject.
+
+## What we expect
+
+- Be respectful. Disagreement is fine; contempt is not.
+- Criticise ideas, not people.
+- Be precise. Vague complaints are not useful to anyone.
+- If you don't understand something, ask. If you know something, share it.
+
+## What is not acceptable
+
+- Personal attacks, insults, or demeaning remarks directed at contributors.
+- Harassment of any kind, in public or in private.
+- Dismissing contributions without explanation.
+- Deliberate disruption of discussions.
+
+## Reporting
+
+If you witness or experience behaviour that violates this code of conduct, report it
+privately to the maintainer. Reports are handled confidentially.
+
+Contact: private email — address available in `pyproject.toml` or on the maintainer's
+GitHub profile ([github.com/biface](https://github.com/biface)).
+
+## Enforcement
+
+The maintainer will investigate reports and may remove comments, close issues, or exclude
+contributors who repeatedly or seriously violate this code of conduct.
+
+## Basis
+
+This code of conduct is adapted from the
+[Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,6 +1,6 @@
 Licence CeCILL-C
 
-**[English version](license.md)**
+**[English version](LICENSE.md)**
 
 ---
 

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,12 @@
+Licence CeCILL-C
+
+**[English version](license.md)**
+
+---
+
+Ce module python permet de gérer la traduction d'applications via un format de fichiers de traduction propre,
+conçu pour coexister avec les standards existants comme gettext (`.po`/`.mo`) et i18next. Ce module est développé
+sous la licence [CeCILL-C](http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html).
+
+Cette licence n'est pas contaminante pour les autres modules si vous vous en servez. Cependant, si vous y
+apportez des modifications, vous devrez le soumettre au préalable ce qui permettra de l'améliorer.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 CeCILL-C License
 
-**[Version française](licence.md)**
+**[Version française](LICENCE.md)**
 
 ---
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,18 +1,12 @@
-CeCILL-C Licence
+CeCILL-C License
 
-# Lecteur français
+**[Version française](licence.md)**
 
-Ce module python permet de gérer des dictionnaires imbriqués en conservant une structure héritée des dictionnaires
-python. Ce module est développé sour la licence [CeCILL-C](http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html).
+---
 
-Cette licence n'est pas contaminante pour les autres modules si vous vous en servez. Cependant, si vous y 
-apportez des modifications, vous devrez le soumettre au préalable ce qui permettra de l'améliorer.
+This python module manages application translations through a dedicated translation file format, designed to
+coexist with existing standards such as gettext (`.po`/`.mo`) and i18next. This module has been developed under
+the [CeCILL-C](http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html) license.
 
-# English reader and ROW
-
-This python module lets you manage nested dictionaries using type inherited from standard python dictionaries.
-This module has been developed under the [CeCILL-C](http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html)
-license.
-
-This license does not contaminate other modules if you use this one. However, if you 
-However, if you make any modifications to it, you'll need to submit them beforehand, which will enable us to improve it.
+This license does not contaminate other modules if you use this one. However, if you
+make any modifications to it, you'll need to submit them beforehand, which will enable us to improve it.

--- a/README.fr.md
+++ b/README.fr.md
@@ -67,7 +67,7 @@ Le projet suit une progression par valeur livrée. Chaque version est indépenda
 
 ### Licence
 
-Voir le fichier [licence.md](licence.md).
+Voir le fichier [licence.md](LICENCE.md).
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,76 @@
+![Python](https://img.shields.io/badge/Language-python-green.svg)
+![Codecov](https://img.shields.io/codecov/c/github/biface/i18n)
+
+--------------
+# i18n-tools
+
+**[English version](README.md)** (for English readers and ROW)
+
+---
+
+## Lecteur français et francophones
+
+### Description
+
+Le projet **i18n-tools** vise à simplifier et moderniser la gestion des traductions dans les applications Python. Il introduit un **nouveau format de fichiers de traduction** flexible, indépendant de toute langue dominante, et conçu pour coexister avec les standards existants comme **gettext** (fichiers `.po`/`.mo`) et **i18next**.
+
+L'objectif est d'offrir une solution **modulaire**, **adaptable** et **sans contrainte linguistique**, avec un support natif pour les **variantes de traduction**, les **pluriels multiples**, et une gestion transparente des langues et des replis.
+
+---
+
+### Roadmap
+
+Le projet suit une progression par valeur livrée. Chaque version est indépendamment utilisable.
+
+| Jalon      | Description                                                                                     | État        |
+|------------|-------------------------------------------------------------------------------------------------|-------------|
+| **v0.1.x** | Stabilisation — corrections des bugs bloquants (B-01 à B-05)                                    | ✅ Livré     |
+| **v0.2.x** | Pont loaders ↔ modèles — `Book.load()`, extension `.i18t`, pont `Config → Repository` (partiel) | ✅ Livré     |
+| **v0.3.x** | Hiérarchie modèles complète — `Corpus`, `FallbackBook`, `Encyclopaedia`, exceptions             | ✅ Livré     |
+| **v0.4.x** | Qualité et couverture — harmonisation des erreurs, couverture ≥ 80 %, documentation Sphinx      | 🔵 En cours |
+| **v0.5.x** | Renforcement architecture — frontière DD-06, finalisation `Config → Repository`                 | 🔵 Planifié |
+| **v0.6.x** | CI/CD et hygiène du dépôt — `uv`/`tox-uv`, `basedpyright`, `.codecov.yml`                        | 🔵 Planifié |
+| **v0.7.x** | Couverture de tests — ≥ 80 % imposé sur tout le package                                         | 🔵 Planifié |
+| **v1.0.0** | i18n-tools natif complet — `core.py`, `fallback.py`, `formatter.py`, CLI, format `.i18t` gelé   | 🔵 Planifié |
+| **v1.x**   | Interopérabilité gettext — import/export `.po`/`.mo` via Babel                                  | 🔵 Horizon  |
+| **v2.x**   | Formats tiers — i18next et autres, hub de conversion central                                    | 🔵 Horizon  |
+| **v3.x**   | CLI complet, API stable, ports Rust/JavaScript                                                  | 🔵 Horizon  |
+
+---
+
+### Fonctionnalités
+
+| Fonctionnalité                              | v0.2.x    | v1.0.0 | v1.x | v2.x |
+|---------------------------------------------|-----------|--------|------|------|
+| Format `.i18t` natif (JSON/YAML)            | ✅         | ✅      | ✅    | ✅    |
+| Identifiants indépendants de la langue      | ✅         | ✅      | ✅    | ✅    |
+| Variantes et pluriels multiples             | ✅         | ✅      | ✅    | ✅    |
+| Chargement d'un `Book` depuis `.i18t`       | ✅         | ✅      | ✅    | ✅    |
+| Sauvegarde d'un `Book` vers `.i18t`         | ✅        | ✅      | ✅    | ✅    |
+| Hiérarchie complète (Corpus, Encyclopaedia) | ✅        | ✅      | ✅    | ✅    |
+| Gestion des replis linguistiques            | ✅        | ✅      | ✅    | ✅    |
+| Interpolation et règles de pluriel actives  | ❌         | ✅      | ✅    | ✅    |
+| Interface CLI/REPL                          | ❌         | ✅      | ✅    | ✅    |
+| Import/export `.po`/`.mo` (Babel/gettext)   | ❌         | ❌      | ✅    | ✅    |
+| Conversion vers i18next                     | ❌         | ❌      | ❌    | ✅    |
+
+---
+
+### Pourquoi ce projet ?
+
+- **Flexibilité** : un format conçu pour s'adapter à tous les besoins de traduction, sans contrainte linguistique — aucune langue n'est dominante.
+- **Expressivité** : support natif des variantes contextuelles (genre, registre, contexte) et des pluriels métier au-delà des règles CLDR.
+- **Extensibilité** : architecture en couches permettant une conversion vers les standards existants (gettext, i18next) sans modifier les modèles.
+- **Interopérabilité** : pont avec l'écosystème Babel pour une compatibilité progressive avec les outils existants.
+
+---
+
+### Licence
+
+Voir le fichier [licence.md](licence.md).
+
+---
+
+### Contact
+
+Pour toute question ou contribution, ouvrez une [issue GitHub](https://github.com/biface/i18n/issues).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The project follows a progression by deliverable value. Each version is independ
 
 ### License
 
-See the [license.md](license.md) file.
+See the [license.md](LICENSE.md) file.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,75 +4,7 @@
 --------------
 # i18n-tools
 
-**[English version](#english-reader-and-row)** (for English readers and ROW)
-
----
-
-## Lecteur français et francophones
-
-### Description
-
-Le projet **i18n-tools** vise à simplifier et moderniser la gestion des traductions dans les applications Python. Il introduit un **nouveau format de fichiers de traduction** flexible, indépendant de toute langue dominante, et conçu pour coexister avec les standards existants comme **gettext** (fichiers `.po`/`.mo`) et **i18next**.
-
-L'objectif est d'offrir une solution **modulaire**, **adaptable** et **sans contrainte linguistique**, avec un support natif pour les **variantes de traduction**, les **pluriels multiples**, et une gestion transparente des langues et des replis.
-
----
-
-### Roadmap
-
-Le projet suit une progression par valeur livrée. Chaque version est indépendamment utilisable.
-
-| Jalon      | Description                                                                                     | État        |
-|------------|-------------------------------------------------------------------------------------------------|-------------|
-| **v0.1.x** | Stabilisation — corrections des bugs bloquants (B-01 à B-05)                                    | ✅ Livré     |
-| **v0.2.x** | Pont loaders ↔ modèles — `Book.load()`, extension `.i18t`, pont `Config → Repository` (partiel) | ✅ Livré     |
-| **v0.3.x** | Hiérarchie modèles complète — `Corpus`, `FallbackBook`, `Encyclopaedia`, exceptions             | 🔵 Planifié |
-| **v0.4.x** | Qualité et couverture — harmonisation des erreurs, couverture ≥ 80 %, documentation Sphinx      | 🔵 Planifié |
-| **v1.0.0** | i18n-tools natif complet — `core.py`, `fallback.py`, `formatter.py`, CLI, format `.i18t` gelé   | 🔵 Planifié |
-| **v1.x**   | Interopérabilité gettext — import/export `.po`/`.mo` via Babel                                  | 🔵 Horizon  |
-| **v2.x**   | Formats tiers — i18next et autres, hub de conversion central                                    | 🔵 Horizon  |
-| **v3.x**   | CLI complet, API stable, ports Rust/JavaScript                                                  | 🔵 Horizon  |
-
----
-
-### Fonctionnalités
-
-| Fonctionnalité                              | v0.2.x    | v1.0.0 | v1.x | v2.x |
-|---------------------------------------------|-----------|--------|------|------|
-| Format `.i18t` natif (JSON/YAML)            | ✅         | ✅      | ✅    | ✅    |
-| Identifiants indépendants de la langue      | ✅         | ✅      | ✅    | ✅    |
-| Variantes et pluriels multiples             | ✅         | ✅      | ✅    | ✅    |
-| Chargement d'un `Book` depuis `.i18t`       | ✅         | ✅      | ✅    | ✅    |
-| Sauvegarde d'un `Book` vers `.i18t`         | 🔵 v0.3.x | ✅      | ✅    | ✅    |
-| Hiérarchie complète (Corpus, Encyclopaedia) | 🔵 v0.3.x | ✅      | ✅    | ✅    |
-| Gestion des replis linguistiques            | 🔵 v0.3.x | ✅      | ✅    | ✅    |
-| Interpolation et règles de pluriel actives  | ❌         | ✅      | ✅    | ✅    |
-| Interface CLI/REPL                          | ❌         | ✅      | ✅    | ✅    |
-| Import/export `.po`/`.mo` (Babel/gettext)   | ❌         | ❌      | ✅    | ✅    |
-| Conversion vers i18next                     | ❌         | ❌      | ❌    | ✅    |
-
----
-
-### Pourquoi ce projet ?
-
-- **Flexibilité** : un format conçu pour s'adapter à tous les besoins de traduction, sans contrainte linguistique — aucune langue n'est dominante.
-- **Expressivité** : support natif des variantes contextuelles (genre, registre, contexte) et des pluriels métier au-delà des règles CLDR.
-- **Extensibilité** : architecture en couches permettant une conversion vers les standards existants (gettext, i18next) sans modifier les modèles.
-- **Interopérabilité** : pont avec l'écosystème Babel pour une compatibilité progressive avec les outils existants.
-
----
-
-### Licence
-
-Voir le fichier [LICENSE.md](LICENSE.md).
-
----
-
-### Contact
-
-Pour toute question ou contribution, ouvrez une [issue GitHub](https://github.com/biface/i18n/issues).
-
----
+**[Version française](README.fr.md)** (lecteur français et francophones)
 
 ---
 
@@ -94,8 +26,11 @@ The project follows a progression by deliverable value. Each version is independ
 |------------|-----------------------------------------------------------------------------------------------|-------------|
 | **v0.1.x** | Stabilisation — fix blocking bugs (B-01 to B-05)                                              | ✅ Delivered |
 | **v0.2.x** | Loaders ↔ models bridge — `Book.load()`, `.i18t` extension, partial `Config → Repository`     | ✅ Delivered |
-| **v0.3.x** | Complete model hierarchy — `Corpus`, `FallbackBook`, `Encyclopaedia`, exceptions              | 🔵 Planned  |
-| **v0.4.x** | Quality and coverage — error handling, ≥ 80% coverage, Sphinx documentation                   | 🔵 Planned  |
+| **v0.3.x** | Complete model hierarchy — `Corpus`, `FallbackBook`, `Encyclopaedia`, exceptions              | ✅ Delivered |
+| **v0.4.x** | Quality and coverage — error handling, ≥ 80% coverage, Sphinx documentation                   | 🔵 In progress |
+| **v0.5.x** | Architecture & layering hardening — DD-06 boundary, `Config → Repository` completion          | 🔵 Planned  |
+| **v0.6.x** | CI/CD & repository hygiene — `uv`/`tox-uv`, `basedpyright`, `.codecov.yml`                     | 🔵 Planned  |
+| **v0.7.x** | Test coverage — ≥ 80% enforced across the package                                             | 🔵 Planned  |
 | **v1.0.0** | Full native i18n-tools — `core.py`, `fallback.py`, `formatter.py`, CLI, `.i18t` format frozen | 🔵 Planned  |
 | **v1.x**   | gettext interoperability — `.po`/`.mo` import/export via Babel                                | 🔵 Horizon  |
 | **v2.x**   | Third-party formats — i18next and others, central conversion hub                              | 🔵 Horizon  |
@@ -111,9 +46,9 @@ The project follows a progression by deliverable value. Each version is independ
 | Language-neutral identifiers                | ✅         | ✅      | ✅    | ✅    |
 | Variants and multiple plurals               | ✅         | ✅      | ✅    | ✅    |
 | Load a `Book` from `.i18t`                  | ✅         | ✅      | ✅    | ✅    |
-| Save a `Book` to `.i18t`                    | 🔵 v0.3.x | ✅      | ✅    | ✅    |
-| Complete hierarchy (Corpus, Encyclopaedia)  | 🔵 v0.3.x | ✅      | ✅    | ✅    |
-| Language fallback management                | 🔵 v0.3.x | ✅      | ✅    | ✅    |
+| Save a `Book` to `.i18t`                    | ✅        | ✅      | ✅    | ✅    |
+| Complete hierarchy (Corpus, Encyclopaedia)  | ✅        | ✅      | ✅    | ✅    |
+| Language fallback management                | ✅        | ✅      | ✅    | ✅    |
 | Interpolation and active plural rules       | ❌         | ✅      | ✅    | ✅    |
 | CLI/REPL interface                          | ❌         | ✅      | ✅    | ✅    |
 | `.po`/`.mo` import/export (Babel/gettext)   | ❌         | ❌      | ✅    | ✅    |
@@ -132,7 +67,7 @@ The project follows a progression by deliverable value. Each version is independ
 
 ### License
 
-See the [LICENSE.md](LICENSE.md) file.
+See the [license.md](license.md) file.
 
 ---
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment, for the first two.
+SPHINXOPTS    ?= -W
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like running "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/_static/images/logo.svg
+++ b/docs/source/_static/images/logo.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="300" height="300" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="i18n-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d97706;stop-opacity:1" />
+    </linearGradient>
+    
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+  
+  <!-- Hexagonal badge (common element) -->
+  <polygon points="150,20 250,75 250,185 150,240 50,185 50,75" 
+           fill="url(#i18n-bg)" 
+           stroke="#ea580c" 
+           stroke-width="4"
+           filter="url(#shadow)"/>
+  
+  <!-- Inner hexagon border -->
+  <polygon points="150,35 235,82.5 235,177.5 150,225 65,177.5 65,82.5" 
+           fill="none" 
+           stroke="#fbbf24" 
+           stroke-width="2"
+           opacity="0.5"/>
+  
+  <!-- Globe with multilingual characters -->
+  <g>
+    <!-- Globe -->
+    <circle cx="150" cy="120" r="55" fill="none" stroke="#ffffff" stroke-width="3.5"/>
+    
+    <!-- Latitude lines -->
+    <ellipse cx="150" cy="120" rx="55" ry="18" fill="none" stroke="#ffffff" stroke-width="2" opacity="0.7"/>
+    <ellipse cx="150" cy="120" rx="55" ry="36" fill="none" stroke="#ffffff" stroke-width="2" opacity="0.7"/>
+    
+    <!-- Longitude lines -->
+    <ellipse cx="150" cy="120" rx="18" ry="55" fill="none" stroke="#ffffff" stroke-width="2" opacity="0.7"/>
+    <ellipse cx="150" cy="120" rx="36" ry="55" fill="none" stroke="#ffffff" stroke-width="2" opacity="0.7"/>
+    
+    <!-- Multilingual characters -->
+    <text x="130" y="105" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="#ffffff">A</text>
+    <text x="148" y="128" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="#ffffff">文</text>
+    <text x="165" y="110" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ffffff">Я</text>
+    <text x="125" y="138" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ffffff">あ</text>
+    <text x="168" y="135" font-family="Arial, sans-serif" font-size="19" font-weight="bold" fill="#ffffff">א</text>
+  </g>
+  
+  <!-- Project name -->
+  <text x="150" y="210" 
+        font-family="'Courier New', monospace" 
+        font-size="24" 
+        font-weight="bold" 
+        fill="#ffffff" 
+        text-anchor="middle">i18n</text>
+  
+  <!-- Tools badge (common element) -->
+  <rect x="110" y="250" width="80" height="30" rx="15" fill="#d97706" stroke="#fbbf24" stroke-width="2"/>
+  <text x="150" y="270" 
+        font-family="Arial, sans-serif" 
+        font-size="14" 
+        font-weight="bold" 
+        fill="#ffffff" 
+        text-anchor="middle">tools</text>
+</svg>

--- a/docs/source/api/modules/loaders/handler.rst
+++ b/docs/source/api/modules/loaders/handler.rst
@@ -4,13 +4,13 @@ Handler module
 .. automodule:: i18n_tools.loaders.handler
 
     .. autofunction:: build_path
+    .. autofunction:: build_book_filename
     .. autofunction:: build_translation_lang_files
     .. autofunction:: check_json_integrity
     .. autofunction:: create_catalog
     .. autofunction:: create_dictionary
     .. autofunction:: create_directory
     .. autofunction:: create_template
-    .. autofunction:: dump_catalog
     .. autofunction:: dump_dictionary
     .. autofunction:: fetch_catalog
     .. autofunction:: fetch_dictionary

--- a/docs/source/api/modules/loaders/index.rst
+++ b/docs/source/api/modules/loaders/index.rst
@@ -1,11 +1,12 @@
 Loaders Module
 ==============
 
-The **Loaders** module is responsible for loading and managing translation files. It is organized into three abstraction layers:
+The **Loaders** module is responsible for loading and managing translation files. It is organized into four abstraction layers:
 
 - **Utils**: Low-level file operations.
 - **Handler**: Intermediate layer for path and file type management.
 - **Loader**: High-level mapping between objects and procedures.
+- **Repository**: Filesystem archive and aggregation operations (backups, multi-module/domain aggregation).
 
 .. toctree::
    :maxdepth: 1
@@ -13,3 +14,4 @@ The **Loaders** module is responsible for loading and managing translation files
    utils
    handler
    loader
+   repository

--- a/docs/source/api/modules/loaders/loader.rst
+++ b/docs/source/api/modules/loaders/loader.rst
@@ -2,12 +2,11 @@ Loader module
 =============
 
 .. automodule:: i18n_tools.loaders.loader
-   :private-members: _load_po, _save_po, _load_pot, _save_pot, _load_mo, _save_mo
 
     .. autofunction:: load_locale_json
+    .. autofunction:: load_book
+    .. autofunction:: save_book
     .. autofunction:: aggregate_locale_json
-    .. autofunction:: load_locale_po
     .. autofunction:: save_locale_json
     .. autofunction:: save_aggregated_locale_json
-    .. autofunction:: save_locale_po
-    .. autofunction:: save_locale_pot
+    .. autofunction:: build_book_filename

--- a/docs/source/concept/repository.rst
+++ b/docs/source/concept/repository.rst
@@ -121,11 +121,11 @@ Key Directories and Files
 
 4. **<module_3>/package_1, <module_3>/package_2, .../**: Subdirectories within a module that represent different packages. Each package directory contains its own ``locales`` directory and an ``_i18n_tools`` directory for metadata.
 
-5. **locales/** (:doc:`I18N_TOOLS_LOCALE <api/constant>`) : This directory, within each module or package directory, contains the ``templates`` directory and language-specific subdirectories.
+5. **locales/** (:ref:`I18N_TOOLS_LOCALE <I18N_TOOLS_LOCALE>`) : This directory, within each module or package directory, contains the ``templates`` directory and language-specific subdirectories.
 
 6. **domain..._name_aggregated.json**: A JSON file at the base of each ``locales`` directory that aggregates metadata for the domain across all language codes. The "_aggregated" suffix helps differentiate it from other metadata files.
 
-7. **templates/** (:doc:`I18N_TOOLS_TEMPLATE <api/constant>`): This directory contains the Portable Object Template (POT) files and JSON metadata files that serve as templates for translations. Each module or package has its own POT file named ``<domain-name>.pot`` and a corresponding JSON metadata file named ``<domain-name>.json``.
+7. **templates/** (:ref:`I18N_TOOLS_TEMPLATE <I18N_TOOLS_TEMPLATE>`): This directory contains the Portable Object Template (POT) files and JSON metadata files that serve as templates for translations. Each module or package has its own POT file named ``<domain-name>.pot`` and a corresponding JSON metadata file named ``<domain-name>.json``.
 
 8. **<language_code>/**: A directory for each language supported by the application within the ``locales`` directory. The language code follows the `IETF language tag <https://en.wikipedia.org/wiki/IETF_language_tag>`_ format (e.g., ``fr`` for French, ``de`` for German).
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.todo',
     'sphinx.ext.intersphinx',
-    'sphinx_rtd_theme',
     # contributions
 ]
 
@@ -40,11 +39,7 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_theme_options = {
-    'navigation_depth': 4,
-    'collapse_navigation': False,
-}
+html_theme = 'furo'
 
 html_use_index = True
 html_search_language = 'en'

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -65,16 +65,19 @@ Quick Start
 Next Steps
 ----------
 
-- Explore the :doc:`Core Concepts <org>` to understand the proprietary format.
-- Learn how to use the :doc:`CLI and GUI <tutorials/cli_usage>` for advanced workflows.
-- Check out the :doc:`API Reference <api>` for programmatic usage.
+- Explore the :doc:`Core Concepts <concept/index>` to understand the proprietary format.
+- Check out the :doc:`API Reference <api/index>` for programmatic usage.
+
+.. todo::
+   Once a CLI/GUI exists (targeted v1.0.0+, DD-30) and the advanced
+   configuration guide is written, re-add links to them here.
 
 ---
 
 Troubleshooting
----------------
+----------------
 
 - **Installation Issues**: Ensure your Python environment is correctly set up.
 - **Command Not Found**: Verify that the ``i18n-tools`` executable is in your system's PATH.
 
-For more help, visit the :doc:`FAQ <usage_guides/advanced_configuration>` or open an issue on the project repository.
+For more help, open an issue on the project repository.

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -48,4 +48,4 @@ Why Use i18n-tools?
 
 If your application requires **dynamic, context-sensitive messages** or **non-standard plural rules**, **i18n-tools** provides the flexibility and control needed to deliver a polished user experience across languages.
 
-For more details, see the :doc:`Overview <index>` or dive into the :doc:`Getting Started <install>` guide.
+For more details, see the :doc:`Overview <index>` or dive into the :doc:`Getting Started <getting_started>` guide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/biface/ndt"
-Repository = "https://github.com/biface/ndt.git"
-Issues = "https://github.com/biface/ndt/issues"
+Homepage = "https://github.com/biface/i18n"
+Repository = "https://github.com/biface/i18n.git"
+Issues = "https://github.com/biface/i18n/issues"
 
 [project.optional-dependencies]
 test = [
@@ -53,7 +53,6 @@ deps = [
     "langcodes",
     "babel",
     "PyYAML",
-    "ndict-tools",
     "toml",
     "polib",
     "pytest",
@@ -105,7 +104,6 @@ deps = [
     "langcodes",
     "babel",
     "PyYAML",
-    "ndict-tools",
     "toml",
     "polib",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,14 @@ test = [
     "isort",
     "bandit"
 ]
+docs = [
+    "Sphinx",
+    "furo"
+]
 
 [tool.tox]
 minversion = "3.24.5"
-envlist = ["py39", "py310", "py311", "py312", "lint", "isort", "black", "fix", "coverage", "bandit", "local", "ci"]
+envlist = ["py39", "py310", "py311", "py312", "lint", "isort", "black", "fix", "coverage", "bandit", "local", "ci", "docs"]
 
 [tool.tox.testenv]
 setenv = { PYTHONPATH = "{toxinidir}/src:{toxinidir}/tests" }
@@ -96,6 +100,16 @@ commands = [
 description = "Run security analysis with bandit"
 deps = ["bandit"]
 commands = ["bandit -r src"]
+
+[tool.tox.testenv.docs]
+description = "Build Sphinx documentation (warnings treated as errors)"
+deps = [
+    "Sphinx",
+    "furo"
+]
+commands = [
+    "sphinx-build -b html docs/source docs/build/html -W"
+]
 
 [tool.tox.testenv.local]
 description = "Run fix, lint, bandit, and coverage in sequence"

--- a/src/i18n_tools/__init__.py
+++ b/src/i18n_tools/__init__.py
@@ -21,13 +21,11 @@ from i18n_tools.__static__ import (
     I18N_TOOLS_MODULE_NAME,
     I18N_TOOLS_ROOT_NAME,
     I18N_TOOLS_TRANSLATION_FILE_EXT,
+    __version__,
 )
 
-__version__ = "0.3.0"
-
 __all__ = [
-    # Models — exposed after __version__ is defined to avoid circular import
-    # (corpus.py imports __version__ from this module)
+    # Models
     "Message",
     "Book",
     "Corpus",
@@ -35,6 +33,7 @@ __all__ = [
     "Encyclopaedia",
     # Configuration
     "Repository",
+    "Config",
     # Constants
     "I18N_TOOLS_CONFIG",
     "I18N_TOOLS_LOCALE",
@@ -45,9 +44,13 @@ __all__ = [
     "__version__",
 ]
 
-# Models imported after __version__ is defined to avoid circular import:
-# corpus.py → from i18n_tools import __version__
-# Refactoring deferred to v0.4.x (DD-19, biface/i18n#47)
+from i18n_tools.config import Config  # noqa: E402
+
+# Models, Repository, and Config can now be imported in any order: __version__
+# and the other shared constants live in __static__.py, which internal modules
+# (corpus.py, loaders/handler.py, loaders/repository.py) import directly,
+# without going through this file. The former import-order constraint
+# (biface/i18n#47, DD-19) no longer applies.
 from i18n_tools.models import (  # noqa: E402
     Book,
     Corpus,

--- a/src/i18n_tools/__static__.py
+++ b/src/i18n_tools/__static__.py
@@ -8,6 +8,17 @@ import os
 from pathlib import Path
 from typing import Literal
 
+__version__ = "0.3.0"
+"""
+This variable stores the package version. It lives here (rather than in
+``__init__.py``) so that internal modules can depend on it without creating
+a circular import back through the package root. Internal consumers should
+import this module (``from i18n_tools import __static__``) and read
+``__static__.__version__`` rather than copy-importing the name, so that an
+override made after import time (``i18n_tools.__static__.__version__ = ...``)
+remains visible everywhere consistently.
+"""
+
 I18N_TRANSLATION_FORMAT = {"json", "yaml"}
 """
 This format defines the set of standard storage files for translations

--- a/src/i18n_tools/loaders/handler.py
+++ b/src/i18n_tools/loaders/handler.py
@@ -122,6 +122,35 @@ def build_path(base_path: str, *sub_dirs: str) -> str:
     return str(cleaned_path)
 
 
+def build_book_filename(
+    domain: str, fmt: Optional[TranslationFileFormat] = None
+) -> Tuple[TranslationFileFormat, str]:
+    """
+    Resolve the storage format (default + validation) and the corresponding
+    `.i18t` filename for a translation domain, without requiring a `Book`
+    instance.
+
+    This is the single place where the default-format and filename-building
+    rules for a translation dictionary are applied — used by `Book`
+    (via `loader.py`, never imported here directly, DD-06) to keep its own
+    format default/validation consistent across its constructor and its
+    `add_format()`/`update_format()` methods, and reusable from `core.py`,
+    `sync.py`, or a future CLI without constructing a `Book` first.
+
+    :param domain: The translation domain name.
+    :type domain: str
+    :param fmt: The desired storage format ("json" or "yaml"). Defaults to
+                "json" if ``None``.
+    :type fmt: Optional[TranslationFileFormat]
+    :return: A ``(format, filename)`` tuple, e.g. ``("json", "messages.json.i18t")``.
+    :rtype: Tuple[TranslationFileFormat, str]
+    :raises ValueError: If ``fmt`` is not a recognised translation format.
+    """
+    _fmt = _validate_translation_format(fmt)
+    filename = f"{domain}.{_fmt}.{I18N_TOOLS_TRANSLATION_FILE_EXT}"
+    return _fmt, filename
+
+
 def file_exists(file_path: str) -> bool:
     """
     Checks if a file exists at the given path.

--- a/src/i18n_tools/loaders/handler.py
+++ b/src/i18n_tools/loaders/handler.py
@@ -201,26 +201,25 @@ def create_template(
     :param domain: The domain name.
     :type domain: str
     """
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            I18N_TOOLS_TEMPLATE,
-        )
-        catalog = Catalog(
-            project=repository[["details", "name"]],
-            version=repository[["details", "version"]],
-            copyright_holder=f"i18n-tools ({__static__.__version__}) builder",
-            msgid_bugs_address=repository[["details", "report-bugs-to"]],
-            fuzzy=(
-                bool(repository[["details", "flags", "fuzzy"]])
-                if ["details", "flags", "fuzzy"] in repository.paths()
-                else True
-            ),
-        )
-        catalog.header_comment = f"""
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        I18N_TOOLS_TEMPLATE,
+    )
+    catalog = Catalog(
+        project=repository[["details", "name"]],
+        version=repository[["details", "version"]],
+        copyright_holder=f"i18n-tools ({__static__.__version__}) builder",
+        msgid_bugs_address=repository[["details", "report-bugs-to"]],
+        fuzzy=(
+            bool(repository[["details", "flags", "fuzzy"]])
+            if ["details", "flags", "fuzzy"] in repository.paths()
+            else True
+        ),
+    )
+    catalog.header_comment = f"""
 # This POT file is generated for PROJECT project.
 # By ORGANIZATION and is dedicated to {domain} domain
 # of translations in {module} module of PROJECT project.
@@ -234,40 +233,37 @@ def create_template(
 # This file is distributed under the same license as the PROJECT
 # project.
 """
-        catalog.domain = domain
-        catalog.mime_headers = [
-            (
-                "Project-Id-Version",
-                f"{repository[['details', 'name']]} {repository[['details', 'version']]}",
-            ),
-            ("Report-Msgid-Bugs-To", repository[["details", "report-bugs-to"]]),
-            ("POT-Creation-Date", repository[["details", "creation_date"]]),
-            ("PO-Revision-Date", "YEAR-MO-DA HO:MI+ZONE"),
-            ("Last-Translator", ""),
-            ("Language-Team", repository[["details", "language_team"]]),
-            ("Language", ""),
-            ("MIME-Version", "1.0"),
-            (
-                "Content-Type",
-                f"{repository[['details', 'content_type']]}; charset=utf-8",
-            ),
-            ("Content-Transfer-Encoding", "8bit"),
-            (
-                "Generated-By",
-                f"i18n-tools ({__static__.__version__}) using Babel ({babel_version})",
-            ),
-        ]
+    catalog.domain = domain
+    catalog.mime_headers = [
+        (
+            "Project-Id-Version",
+            f"{repository[['details', 'name']]} {repository[['details', 'version']]}",
+        ),
+        ("Report-Msgid-Bugs-To", repository[["details", "report-bugs-to"]]),
+        ("POT-Creation-Date", repository[["details", "creation_date"]]),
+        ("PO-Revision-Date", "YEAR-MO-DA HO:MI+ZONE"),
+        ("Last-Translator", ""),
+        ("Language-Team", repository[["details", "language_team"]]),
+        ("Language", ""),
+        ("MIME-Version", "1.0"),
+        (
+            "Content-Type",
+            f"{repository[['details', 'content_type']]}; charset=utf-8",
+        ),
+        ("Content-Transfer-Encoding", "8bit"),
+        (
+            "Generated-By",
+            f"i18n-tools ({__static__.__version__}) using Babel ({babel_version})",
+        ),
+    ]
 
-        template_file = path + f"/{domain}.pot"
-        if not _exist_path(template_file):
-            _save_text(template_file, catalog)
-        else:
-            raise FileExistsError(
-                f"The path '{template_file}' already exists. You cannot overwrite it."
-            )
-
-    except Exception as e:
-        raise e
+    template_file = path + f"/{domain}.pot"
+    if not _exist_path(template_file):
+        _save_text(template_file, catalog)
+    else:
+        raise FileExistsError(
+            f"The path '{template_file}' already exists. You cannot overwrite it."
+        )
 
 
 def create_catalog(
@@ -289,28 +285,25 @@ def create_catalog(
     :type domain: str
     """
 
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    catalog = fetch_template(repository, module, domain)
+    catalog_path = path + f"/{domain}.po"
+    catalog.locale = Locale.parse(language, sep="-")
+    catalog.domain = domain
+    if not _exist_path(catalog_path):
+        _save_text(catalog_path, catalog)
+        _convert_catalog(catalog_path)
+    else:
+        raise FileExistsError(
+            f"The path '{catalog_path}' already exists. You cannot overwrite it"
         )
-        catalog = fetch_template(repository, module, domain)
-        catalog_path = path + f"/{domain}.po"
-        catalog.locale = Locale.parse(language, sep="-")
-        catalog.domain = domain
-        if not _exist_path(catalog_path):
-            _save_text(catalog_path, catalog)
-            _convert_catalog(catalog_path)
-        else:
-            raise FileExistsError(
-                f"The path '{catalog_path}' already exists. You cannot overwrite it"
-            )
-    except Exception as e:
-        raise e
 
 
 def create_dictionary(
@@ -335,26 +328,23 @@ def create_dictionary(
     :param domain: The domain name.
     :type domain: str
     """
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    # Default behavior remains JSON when fmt is None
+    dictionary_path = _build_dictionary_path(path, domain, fmt)
+    _fmt = _validate_translation_format(fmt)
+    if not _exist_path(dictionary_path):
+        _save_by_format(dictionary_path, {}, _fmt)
+    else:
+        raise FileExistsError(
+            f"The path '{dictionary_path}' already exists. You cannot overwrite it"
         )
-        # Default behavior remains JSON when fmt is None
-        dictionary_path = _build_dictionary_path(path, domain, fmt)
-        _fmt = _validate_translation_format(fmt)
-        if not _exist_path(dictionary_path):
-            _save_by_format(dictionary_path, {}, _fmt)
-        else:
-            raise FileExistsError(
-                f"The path '{dictionary_path}' already exists. You cannot overwrite it"
-            )
-    except Exception as e:
-        raise e
 
 
 # Read operations
@@ -378,20 +368,17 @@ def fetch_template(
     :rtype: str
     """
 
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            I18N_TOOLS_TEMPLATE,
-        )
-        template_file = path + f"/{domain}.pot"
-        catalog = _load_text(template_file)
-        catalog.domain = domain
-        catalog.copyright_holder = "i18n-tools builder"
-    except Exception as e:
-        raise e
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        I18N_TOOLS_TEMPLATE,
+    )
+    template_file = path + f"/{domain}.pot"
+    catalog = _load_text(template_file)
+    catalog.domain = domain
+    catalog.copyright_holder = "i18n-tools builder"
 
     return catalog
 
@@ -415,21 +402,18 @@ def fetch_catalog(
     :return: The translation catalog.
     :rtype: Catalog
     """
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
-        )
-        catalog_path = path + f"/{domain}.po"
-        catalog = _load_text(catalog_path)
-        catalog.domain = domain
-        catalog.copyright_holder = "i18n-tools builder"
-    except Exception as e:
-        raise e
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    catalog_path = path + f"/{domain}.po"
+    catalog = _load_text(catalog_path)
+    catalog.domain = domain
+    catalog.copyright_holder = "i18n-tools builder"
 
     return catalog
 
@@ -458,20 +442,17 @@ def fetch_dictionary(
     :rtype: Dict[str, Any]
     """
 
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
-        )
-        dictionary_path = _build_dictionary_path(path, domain, fmt)
-        _fmt = _validate_translation_format(fmt)
-        dictionary = _load_by_format(dictionary_path, _fmt)
-    except Exception as e:
-        raise e
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    dictionary_path = _build_dictionary_path(path, domain, fmt)
+    _fmt = _validate_translation_format(fmt)
+    dictionary = _load_by_format(dictionary_path, _fmt)
 
     return dictionary
 
@@ -506,54 +487,50 @@ def update_catalog(
 
     # TODO: Must update template file as well
 
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
-        )
-        catalog_path = path + f"/{domain}.po"
-        catalog = _load_text(catalog_path)
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    catalog_path = path + f"/{domain}.po"
+    catalog = _load_text(catalog_path)
 
-        for key, value in data.items():
-            if isinstance(value, dict):
-                # Handle pluralizable messages
-                string_value = value.get("string", "")
+    for key, value in data.items():
+        if isinstance(value, dict):
+            # Handle pluralizable messages
+            string_value = value.get("string", "")
 
-                # If the key is a tuple/list (pluralizable) and the string is not,
-                # convert the string to a tuple with appropriate number of elements
-                if isinstance(key, (tuple, list)) and not isinstance(
-                    string_value, (tuple, list)
-                ):
-                    # For pluralizable messages, string should be a tuple/list
-                    # with the same number of elements as the key
-                    if string_value:
-                        # If we have a string, use it as the first element (singular form)
-                        # and add empty strings for the plural forms
-                        string_value = tuple([string_value] + [""] * (len(key) - 1))
-                    else:
-                        # If we don't have a string, create a tuple with empty strings
-                        string_value = tuple([""] * len(key))
+            # If the key is a tuple/list (pluralizable) and the string is not,
+            # convert the string to a tuple with appropriate number of elements
+            if isinstance(key, (tuple, list)) and not isinstance(
+                string_value, (tuple, list)
+            ):
+                # For pluralizable messages, string should be a tuple/list
+                # with the same number of elements as the key
+                if string_value:
+                    # If we have a string, use it as the first element (singular form)
+                    # and add empty strings for the plural forms
+                    string_value = tuple([string_value] + [""] * (len(key) - 1))
+                else:
+                    # If we don't have a string, create a tuple with empty strings
+                    string_value = tuple([""] * len(key))
 
-                message = catalog.add(
-                    id=key,
-                    string=string_value,
-                    locations=value.get("locations", ()),
-                    previous_id=value.get("previous_id", ""),
-                    flags=["python-format"],
-                )
+            message = catalog.add(
+                id=key,
+                string=string_value,
+                locations=value.get("locations", ()),
+                previous_id=value.get("previous_id", ""),
+                flags=["python-format"],
+            )
 
-            else:
-                raise ValueError(f"{value} is not a dictionary")
+        else:
+            raise ValueError(f"{value} is not a dictionary")
 
-        _save_text(catalog_path, catalog)
-        _convert_catalog(catalog_path)
-
-    except Exception as e:
-        raise e
+    _save_text(catalog_path, catalog)
+    _convert_catalog(catalog_path)
 
 
 def update_dictionary(
@@ -581,31 +558,27 @@ def update_dictionary(
     :type data: Dict[str, Any]
     """
 
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    dictionary_path = _build_dictionary_path(path, domain, fmt)
+    _fmt = _validate_translation_format(fmt)
+    dictionary = _load_by_format(dictionary_path, _fmt)
+
+    if not check_json_integrity(data):
+        raise ValueError(
+            f"The dictionary {data} is not compatible with i18n-tools translations"
         )
-        dictionary_path = _build_dictionary_path(path, domain, fmt)
-        _fmt = _validate_translation_format(fmt)
-        dictionary = _load_by_format(dictionary_path, _fmt)
 
-        if not check_json_integrity(data):
-            raise ValueError(
-                f"The dictionary {data} is not compatible with i18n-tools translations"
-            )
+    for key, item in data.items():
+        dictionary[key] = item
 
-        for key, item in data.items():
-            dictionary[key] = item
-
-        _save_by_format(dictionary_path, dictionary, _fmt)
-
-    except Exception as e:
-        raise e
+    _save_by_format(dictionary_path, dictionary, _fmt)
 
 
 def dump_dictionary(
@@ -633,27 +606,23 @@ def dump_dictionary(
     :type data: Dict[str, Any]
     """
 
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    dictionary_path = _build_dictionary_path(path, domain, fmt)
+    _fmt = _validate_translation_format(fmt)
+
+    if not check_json_integrity(data):
+        raise ValueError(
+            f"The dictionary {data} is not compatible with i18n-tools translations"
         )
-        dictionary_path = _build_dictionary_path(path, domain, fmt)
-        _fmt = _validate_translation_format(fmt)
 
-        if not check_json_integrity(data):
-            raise ValueError(
-                f"The dictionary {data} is not compatible with i18n-tools translations"
-            )
-
-        _save_by_format(dictionary_path, data, _fmt)
-
-    except Exception as e:
-        raise e
+    _save_by_format(dictionary_path, data, _fmt)
 
 
 # Delete operations
@@ -676,18 +645,15 @@ def remove_template(
     :raises FileNotFoundError: If the template file does not exist.
     """
 
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            I18N_TOOLS_TEMPLATE,
-        )
-        template_path = path + f"/{domain}.pot"
-        _remove_file(template_path)
-    except Exception as e:
-        raise e
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        I18N_TOOLS_TEMPLATE,
+    )
+    template_path = path + f"/{domain}.pot"
+    _remove_file(template_path)
 
 
 def remove_catalog(
@@ -709,20 +675,17 @@ def remove_catalog(
     :raises FileNotFoundError: If the catalog or machine file does not exist.
     """
 
-    try:
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
-        )
-        catalog_path = path + f"/{domain}.po"
-        machine_path = path + f"/{domain}.mo"
-        _remove_file(catalog_path)
-        _remove_file(machine_path)
-    except Exception as e:
-        raise e
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    catalog_path = path + f"/{domain}.po"
+    machine_path = path + f"/{domain}.mo"
+    _remove_file(catalog_path)
+    _remove_file(machine_path)
 
 
 def remove_dictionary(
@@ -747,19 +710,16 @@ def remove_dictionary(
     :type domain: str
     :raises FileNotFoundError: If the dictionary file does not exist.
     """
-    try:
-        _check_domains(repository, module, [domain])
-        path = build_path(
-            repository[["paths", "repository"]],
-            module,
-            I18N_TOOLS_LOCALE,
-            language,
-            I18N_TOOLS_MESSAGES,
-        )
-        dictionary_path = _build_dictionary_path(path, domain, fmt)
-        _remove_file(dictionary_path)
-    except Exception as e:
-        raise e
+    _check_domains(repository, module, [domain])
+    path = build_path(
+        repository[["paths", "repository"]],
+        module,
+        I18N_TOOLS_LOCALE,
+        language,
+        I18N_TOOLS_MESSAGES,
+    )
+    dictionary_path = _build_dictionary_path(path, domain, fmt)
+    _remove_file(dictionary_path)
 
 
 # Managing configuration files
@@ -937,17 +897,11 @@ def _verify_target_domain(
     :type target_domain: str.
     :return: Nothing
     :rtype: None
-    :raises ValueError: If any domain is not registered in the repository.
+    :raises ValueError: If the target module or the target domain is not
+                         registered in the repository.
     """
-    try:
-        _verify_target_module(repository, target_module)
-        if target_domain not in repository[["domains", target_module]]:
-            raise IndexError(
-                f"The target domain '{target_domain}' is not registered in the repository"
-            )
-    except IndexError as e:
-        raise e
-    except Exception as e:
+    _verify_target_module(repository, target_module)
+    if target_domain not in repository[["domains", target_module]]:
         raise ValueError(
-            f"The target module '{target_module}' is not registered in the repository"
+            f"The target domain '{target_domain}' is not registered in the repository"
         )

--- a/src/i18n_tools/loaders/handler.py
+++ b/src/i18n_tools/loaders/handler.py
@@ -579,33 +579,6 @@ def update_dictionary(
         raise e
 
 
-def dump_catalog(
-    repository: StrictNestedDictionary,
-    module: str,
-    language: str,
-    domain: str,
-    data: Dict[any, Dict[str, str]],
-) -> None:
-    """
-    Dump the translation catalog for a given language and domain.
-
-    This function saves the provided translation catalog to the specified .po file
-    and updates the corresponding .mo file.
-
-    :param repository: The data structure representing the translation repository.
-    :type repository: StrictNestedDictionary
-    :param module: The module path.
-    :type module: str
-    :param language: The language code.
-    :type language: str
-    :param domain: The domain name.
-    :type domain: str
-    :param data: An adapted translation dictionary.
-    :type data: Dict[str, Dict[str, str]]
-    """
-    pass
-
-
 def dump_dictionary(
     repository: StrictNestedDictionary,
     module: str,

--- a/src/i18n_tools/loaders/handler.py
+++ b/src/i18n_tools/loaders/handler.py
@@ -19,7 +19,7 @@ from babel.messages.catalog import Catalog, Message
 from ndict_tools import StrictNestedDictionary
 
 # import i18n_tools
-from i18n_tools import __version__ as i18n_tools_version
+from i18n_tools import __static__
 
 from ..__static__ import (
     I18N_TOOLS_CONFIG,
@@ -183,7 +183,7 @@ def create_template(
         catalog = Catalog(
             project=repository[["details", "name"]],
             version=repository[["details", "version"]],
-            copyright_holder=f"i18n-tools ({i18n_tools_version}) builder",
+            copyright_holder=f"i18n-tools ({__static__.__version__}) builder",
             msgid_bugs_address=repository[["details", "report-bugs-to"]],
             fuzzy=(
                 bool(repository[["details", "flags", "fuzzy"]])
@@ -225,7 +225,7 @@ def create_template(
             ("Content-Transfer-Encoding", "8bit"),
             (
                 "Generated-By",
-                f"i18n-tools ({i18n_tools_version}) using Babel ({babel_version})",
+                f"i18n-tools ({__static__.__version__}) using Babel ({babel_version})",
             ),
         ]
 

--- a/src/i18n_tools/loaders/loader.py
+++ b/src/i18n_tools/loaders/loader.py
@@ -11,119 +11,18 @@ managing `.pot` files for translation projects.
 """
 
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
-from babel.messages.catalog import Catalog
-from babel.messages.mofile import read_mo, write_mo
-from babel.messages.pofile import read_po, write_po
-
+from i18n_tools.loaders.handler import build_book_filename as _build_book_filename
 from i18n_tools.loaders.handler import check_json_integrity
 from i18n_tools.loaders.utils import (
     _create_gzip,
     _detect_format,
+    _load_by_format,
     _load_json,
     _save_by_format,
     _save_json,
 )
-
-
-def _load_po(file_path: str) -> Catalog:
-    """
-    Load a PO file and return its content as a Babel Catalog.
-    :param file_path: Path to the PO file.
-    :type file_path: str
-    :return: Babel Catalog object.
-    :rtype: Catalog
-    :raises FileNotFoundError: File not found.
-    """
-    try:
-        with open(file_path, "r", encoding="utf-8") as po_file:
-            return read_po(po_file)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
-
-
-def _save_po(file_path: str, po_data: Catalog) -> None:
-    """
-    Save a PO file using Babel.
-    :param file_path: Path to the PO file.
-    :type file_path: str
-    :param po_data: Babel Catalog object.
-    :type po_data: Catalog
-    :return: None
-    :raises FileNotFoundError: File not found.
-    """
-    try:
-        with open(file_path, "r", encoding="utf-8") as po_file:
-            write_po(po_file, po_data)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
-
-
-def _load_pot(file_path: str) -> Catalog:
-    """
-    Load a POT file and return its content as a Babel Catalog.
-    :param file_path: Path to the POT file.
-    :type file_path: str
-    :return: Babel Catalog object.
-    :rtype: Catalog
-    :raises FileNotFoundError: File not found.
-    """
-    try:
-        with open(file_path, "r", encoding="utf-8") as pot_file:
-            return read_po(pot_file)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
-
-
-def _save_pot(file_path: str, pot_data: Catalog) -> None:
-    """
-    Save a POT file using Babel.
-    :param file_path: Path to the POT file.
-    :type file_path: str
-    :param pot_data: Babel Catalog object.
-    :type pot_data: Catalog
-    :return: None
-    :raises FileNotFoundError: File not found.
-    """
-    try:
-        with open(file_path, "w", encoding="utf-8") as pot_file:
-            write_po(pot_file, pot_data)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
-
-
-def _load_mo(file_path: str) -> Catalog:
-    """
-    Load a MO file and return its content as a Babel Catalog.
-    :param file_path: Path to the MO file.
-    :type file_path: str
-    :return: Babel Catalog object.
-    :rtype: Catalog
-    :raises FileNotFoundError: File not found.
-    """
-    try:
-        with open(file_path, "rb") as mo_file:
-            return read_mo(mo_file)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
-
-
-def _save_mo(file_path: str, mo_data: Catalog) -> None:
-    """
-    Save a MO file using Babel.
-    :param file_path: Path to the MO file.
-    :type file_path: str
-    :param mo_data: Babel Catalog object.
-    :type mo_data: Catalog
-    :return: None
-    :raises FileNotFoundError: File not found.
-    """
-    try:
-        with open(file_path, "wb") as mo_file:
-            write_mo(mo_file, mo_data)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
 
 
 def load_locale_json(file_path: str) -> Dict[str, Any]:
@@ -161,8 +60,9 @@ def load_book(file_path: str) -> Dict[str, Any]:
     """
     Load a .i18t dictionary file and return its contents as a filtered dict (DD-15, DD-16, DD-34).
 
-    The serialisation format is detected from the file extension (DD-34).
-    The reserved keys ``.i18n_tools`` and ``metadata`` are silently ignored.
+    The serialisation format is detected from the file extension (DD-34),
+    symmetrically to :func:`save_book`. The reserved keys ``.i18n_tools``
+    and ``metadata`` are silently ignored.
 
     :param file_path: Path to the .i18t translation file.
     :type file_path: str
@@ -172,7 +72,10 @@ def load_book(file_path: str) -> Dict[str, Any]:
     :raises FileNotFoundError: If the file does not exist.
     :raises ValueError: If the file fails the integrity check.
     """
-    data = load_locale_json(file_path)
+    fmt = _detect_format(file_path)
+    data = _load_by_format(file_path, fmt)
+    if not check_json_integrity(data):
+        raise ValueError(f"Integrity check failed for file: {file_path}")
     result = {}
     for msgid, matrix in data.items():
         if msgid in (".i18n_tools", "metadata"):
@@ -266,20 +169,6 @@ def aggregate_locale_json(
     return aggregated_data
 
 
-def load_locale_po(file_path: str) -> Catalog:
-    """
-    Public interface to load a PO locale file with integrity check.
-
-    :param file_path: Path to the PO locale file.
-    :type file_path: str
-    :return: Babel Catalog object.
-    :rtype: Catalog
-    :raises FileNotFoundError: If the file is not found.
-    :raises ValueError: If the file is not a valid PO file or fails the integrity check.
-    """
-    return _load_po(file_path)
-
-
 def save_locale_json(file_path: str, data: Dict[str, Any]) -> None:
     """
     Save data to a JSON locale file.
@@ -328,21 +217,21 @@ def save_aggregated_locale_json(
         module_json_path.unlink()
 
 
-def save_locale_po(file_path: str, po_data: Catalog) -> None:
+def build_book_filename(domain: str, fmt: Union[str, None] = None) -> Tuple[str, str]:
     """
-    The public interface to _save_po
-    :param file_path:
-    :param po_data:
-    :return:
-    """
-    _save_po(file_path, po_data)
+    Pass-through to :func:`i18n_tools.loaders.handler.build_book_filename`.
 
+    Kept here so that `Book` (`models/corpus.py`) only ever talks to
+    `loader.py`, consistent with the existing `load_book`/`save_book`
+    pattern (DD-06, DD-08) — never directly to `handler.py`.
 
-def save_locale_pot(file_path: str, po_data: Catalog) -> None:
+    :param domain: The translation domain name.
+    :type domain: str
+    :param fmt: The desired storage format ("json" or "yaml"). Defaults to
+                "json" if ``None``.
+    :type fmt: Union[str, None]
+    :return: A ``(format, filename)`` tuple.
+    :rtype: Tuple[str, str]
+    :raises ValueError: If ``fmt`` is not a recognised translation format.
     """
-    The public interface to _save_pot
-    :param file_path:
-    :param po_data:
-    :return:
-    """
-    _save_pot(file_path, po_data)
+    return _build_book_filename(domain, fmt)

--- a/src/i18n_tools/loaders/loader.py
+++ b/src/i18n_tools/loaders/loader.py
@@ -28,7 +28,7 @@ from i18n_tools.loaders.utils import (
 def load_locale_json(file_path: str) -> Dict[str, Any]:
     """
     This function load a JSON file in the locales repository and containing i18next data. The structure of this
-    dictionary is as follows:
+    dictionary is as follows::
 
         {
             "msgid_001": [

--- a/src/i18n_tools/loaders/repository.py
+++ b/src/i18n_tools/loaders/repository.py
@@ -19,12 +19,12 @@ from ndict_tools import StrictNestedDictionary
 from i18n_tools.__static__ import (
     I18N_TOOLS_BACKUP,
     I18N_TOOLS_CONFIG,
+    I18N_TOOLS_LOCALE,
     I18N_TOOLS_MESSAGES,
     I18N_TOOLS_TEMPLATE,
 )
 from i18n_tools.locale import get_all_languages
 
-from .. import I18N_TOOLS_LOCALE
 from .handler import (
     _verify_available_languages,
     _verify_paths_and_modules,

--- a/src/i18n_tools/loaders/utils.py
+++ b/src/i18n_tools/loaders/utils.py
@@ -65,11 +65,8 @@ def _create_empty_file(file_path: Union[Path, str]) -> None:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "w", encoding="utf-8") as empty_file:
-            empty_file.write("")
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "w", encoding="utf-8") as empty_file:
+        empty_file.write("")
 
 
 def _create_directory(file_path: Union[Path, str]) -> None:
@@ -106,11 +103,8 @@ def _create_empty_json(file_path: Union[Path, str]) -> None:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "w", encoding="utf-8") as json_file:
-            json.dump({}, json_file, ensure_ascii=False, indent=4)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "w", encoding="utf-8") as json_file:
+        json.dump({}, json_file, ensure_ascii=False, indent=4)
 
 
 def _load_json(file_path: Union[Path, str]) -> Dict[str, Any]:
@@ -126,11 +120,8 @@ def _load_json(file_path: Union[Path, str]) -> Dict[str, Any]:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "r", encoding="utf-8") as json_file:
-            return json.load(json_file)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "r", encoding="utf-8") as json_file:
+        return json.load(json_file)
 
 
 def _save_json(file_path: Union[Path, str], data: Dict[str, Any]) -> None:
@@ -147,11 +138,8 @@ def _save_json(file_path: Union[Path, str], data: Dict[str, Any]) -> None:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "w", encoding="utf-8") as json_file:
-            json.dump(data, json_file, ensure_ascii=False, indent=4)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "w", encoding="utf-8") as json_file:
+        json.dump(data, json_file, ensure_ascii=False, indent=4)
 
 
 def _load_yaml(file_path: Union[Path, str]) -> Dict[str, Any]:
@@ -162,11 +150,8 @@ def _load_yaml(file_path: Union[Path, str]) -> Dict[str, Any]:
     """
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "r", encoding="utf-8") as yaml_file:
-            return yaml.load(yaml_file, Loader=yaml.SafeLoader)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "r", encoding="utf-8") as yaml_file:
+        return yaml.load(yaml_file, Loader=yaml.SafeLoader)
 
 
 def _save_yaml(file_path: Union[Path, str], data: Dict[str, Any]) -> None:
@@ -178,11 +163,8 @@ def _save_yaml(file_path: Union[Path, str], data: Dict[str, Any]) -> None:
     """
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "w", encoding="utf-8") as yaml_file:
-            yaml.dump(data, yaml_file, Dumper=yaml.SafeDumper)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "w", encoding="utf-8") as yaml_file:
+        yaml.dump(data, yaml_file, Dumper=yaml.SafeDumper)
 
 
 def _validate_translation_format(
@@ -245,11 +227,8 @@ def _load_toml(file_path: Union[Path, str]) -> Dict[str, Any]:
     """
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "r", encoding="utf-8") as toml_file:
-            return toml.load(toml_file)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "r", encoding="utf-8") as toml_file:
+        return toml.load(toml_file)
 
 
 def _save_toml(file_path: Union[Path, str], data: Dict[str, Any]) -> None:
@@ -260,11 +239,8 @@ def _save_toml(file_path: Union[Path, str], data: Dict[str, Any]) -> None:
     :return:
     """
     file_path = __check_path(file_path)
-    try:
-        with open(file_path, "w", encoding="utf-8") as toml_file:
-            toml.dump(data, toml_file)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "w", encoding="utf-8") as toml_file:
+        toml.dump(data, toml_file)
 
 
 # PO file handling with polib
@@ -283,11 +259,8 @@ def _load_text(file_path: Union[Path, str]) -> Catalog:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "r", encoding="utf-8") as po_file:
-            return read_po(po_file)
-    except FileNotFoundError:
-        raise FileNotFoundError(f'File "{file_path}" not found.')
+    with open(file_path, "r", encoding="utf-8") as po_file:
+        return read_po(po_file)
 
 
 def _save_text(file_path: Union[Path, str], catalog: Catalog) -> None:
@@ -303,11 +276,8 @@ def _save_text(file_path: Union[Path, str], catalog: Catalog) -> None:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "wb") as po_file:
-            write_po(po_file, catalog, sort_output=True, include_previous=False)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "wb") as po_file:
+        write_po(po_file, catalog, sort_output=True, include_previous=False)
 
 
 # MO file handling with polib
@@ -326,11 +296,8 @@ def _load_machine(file_path: Union[Path, str]) -> Catalog:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "rb") as mo_file:
-            return read_mo(mo_file)
-    except FileNotFoundError:
-        raise FileNotFoundError(f'File "{file_path}" not found.')
+    with open(file_path, "rb") as mo_file:
+        return read_mo(mo_file)
 
 
 def _save_machine(file_path: Union[Path, str], catalog: Catalog) -> None:
@@ -346,11 +313,8 @@ def _save_machine(file_path: Union[Path, str], catalog: Catalog) -> None:
 
     file_path = __check_path(file_path)
 
-    try:
-        with open(file_path, "wb") as mo_file:
-            write_mo(mo_file, catalog)
-    except Exception as exception:
-        raise FileNotFoundError(f'File "{file_path}" not found.') from exception
+    with open(file_path, "wb") as mo_file:
+        write_mo(mo_file, catalog)
 
 
 def _convert_catalog(file_path: Union[Path, str]) -> None:
@@ -359,20 +323,14 @@ def _convert_catalog(file_path: Union[Path, str]) -> None:
 
     :param file_path: Path to the PO file.
     :type file_path: str
-    :raises IOError: If there is an error writing the file.
     """
 
     file_path = __check_path(file_path)
 
-    try:
-        catalog = _load_text(file_path)
-        mo_file_path = file_path.with_suffix(".mo")
-        with open(mo_file_path, "wb") as mo_file:
-            write_mo(mo_file, catalog)
-    except Exception as exception:
-        raise IOError(
-            f'Error converting file "{file_path}" to MO format.'
-        ) from exception
+    catalog = _load_text(file_path)
+    mo_file_path = file_path.with_suffix(".mo")
+    with open(mo_file_path, "wb") as mo_file:
+        write_mo(mo_file, catalog)
 
 
 # Configuration file load and save
@@ -384,56 +342,47 @@ def _load_config_file(config_path: Union[Path, str]) -> dict:
 
     :param config_path: Path to the configuration file.
     :raises ValueError: If the file format is unsupported.
-    :raises Exception: For errors during loading.
+    :raises FileNotFoundError: If the file does not exist.
     :return: The configuration content as a dictionary.
     """
 
     config_path = __check_path(config_path)
     [file_extension] = config_path.suffixes
 
-    try:
-        if not __check_config_extension(file_extension):
-            raise ValueError(f"Unsupported configuration file format: {file_extension}")
-        else:
-            with open(config_path, "r", encoding="utf-8") as file:
-                if file_extension == ".yaml":
-                    return yaml.safe_load(file)
-                elif file_extension == ".toml":
-                    return toml.load(file)
-                elif file_extension == ".json":
-                    return json.load(file)
-    except Exception as e:
-        raise Exception(f"Error loading configuration file: {config_path}. {e}")
+    if not __check_config_extension(file_extension):
+        raise ValueError(f"Unsupported configuration file format: {file_extension}")
+
+    with open(config_path, "r", encoding="utf-8") as file:
+        if file_extension in {".yaml", ".yml"}:
+            return yaml.safe_load(file)
+        elif file_extension == ".toml":
+            return toml.load(file)
+        elif file_extension == ".json":
+            return json.load(file)
 
 
 def _save_config_file(config_path: Union[Path, str], data: dict) -> None:
     """
-    Helper function to load the configuration file based on its extension.
+    Helper function to save the configuration file based on its extension.
 
     :param config_path: Path to the configuration file.
     :raises ValueError: If the file format is unsupported.
-    :raises Exception: For errors during loading.
-    :return: The configuration content as a dictionary.
+    :return: None
     """
 
     config_path = __check_path(config_path)
     [file_extension] = config_path.suffixes
 
-    try:
-        if not __check_config_extension(file_extension):
-            raise ValueError(f"Unsupported configuration file format: {file_extension}")
-        else:
-            with open(config_path, "w", encoding="utf-8") as cf:
-                if file_extension == ".json":
-                    json.dump(data, cf, indent=4)
-                elif file_extension in {".yaml", ".yml"}:
-                    yaml.safe_dump(data, cf, default_flow_style=False)
-                elif file_extension == ".toml":
-                    toml.dump(data, cf)
-    except ValueError as uff:
-        raise uff
-    except Exception as e:
-        raise Exception(f"Error saving configuration file: {config_path}. {e}")
+    if not __check_config_extension(file_extension):
+        raise ValueError(f"Unsupported configuration file format: {file_extension}")
+
+    with open(config_path, "w", encoding="utf-8") as cf:
+        if file_extension == ".json":
+            json.dump(data, cf, indent=4)
+        elif file_extension in {".yaml", ".yml"}:
+            yaml.safe_dump(data, cf, default_flow_style=False)
+        elif file_extension == ".toml":
+            toml.dump(data, cf)
 
 
 # Utility functions
@@ -654,14 +603,11 @@ def _check_domains(
     :rtype: bool
     :raises: ValueError
     """
-    try:
-        _check_module(repository, [module])
-        for domain in domain_list:
-            if domain not in repository[["domains", module]]:
-                raise ValueError(
-                    f"Domain {domain} not found in repository : {repository[['domains', module]]}"
-                )
-    except ValueError as e:
-        raise e
+    _check_module(repository, [module])
+    for domain in domain_list:
+        if domain not in repository[["domains", module]]:
+            raise ValueError(
+                f"Domain {domain} not found in repository : {repository[['domains', module]]}"
+            )
 
     return True

--- a/src/i18n_tools/models/corpus.py
+++ b/src/i18n_tools/models/corpus.py
@@ -11,8 +11,8 @@ from i18n_tools.converter import (
     i18n_tools_format_to_message_dict,
     message_to_i18n_tools_format,
 )
+from i18n_tools.loaders.loader import build_book_filename
 from i18n_tools.loaders.loader import load_book as _load_book
-from i18n_tools.loaders.utils import _validate_translation_format
 from i18n_tools.locale import normalize_language_tag
 
 
@@ -1803,7 +1803,9 @@ class Book:
         self.messages = StrictNestedDictionary()
 
         # Core metadata for naming and storage format
-        self.format = kwargs.pop("format", "json")
+        self.format, self.filename = build_book_filename(
+            self.domain, kwargs.pop("format", None)
+        )
 
         # Build metadata dictionary (without language, domain, format)
         self.metadata = StrictNestedDictionary(
@@ -1837,8 +1839,6 @@ class Book:
         self.metadata[["count", "messages"]] = len(self.messages)
         # Compute statistics based on current messages
         self._compute_statistics()
-        # Set filename
-        self.__set_filename()
 
     # --- Attribute management for language, domain, and format ---
     def __set_filename(self) -> None:
@@ -1904,14 +1904,11 @@ class Book:
         if getattr(self, "format", None) is not None:
             raise ValueError("Format is already set for this book")
 
-        # Validate using shared loader utils
-        self.format = _validate_translation_format(fmt)
-        self.__set_filename()
+        self.format, self.filename = build_book_filename(self.domain, fmt)
 
     def update_format(self, fmt: TranslationFileFormat) -> None:
         """Update the format hint."""
-        self.format = _validate_translation_format(fmt)
-        self.__set_filename()
+        self.format, self.filename = build_book_filename(self.domain, fmt)
 
     def remove_format(self) -> None:
         """Unset the format hint."""

--- a/src/i18n_tools/models/corpus.py
+++ b/src/i18n_tools/models/corpus.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from ndict_tools import StrictNestedDictionary
 
-from i18n_tools import __version__
+from i18n_tools import __static__
 from i18n_tools.__static__ import I18N_TOOLS_TRANSLATION_FILE_EXT, TranslationFileFormat
 from i18n_tools.converter import (
     i18n_tools_format_to_message_dict,
@@ -35,7 +35,7 @@ def _check_index_dict(dictionary: Dict[int, str]) -> bool:
 def _build_empty_metadata() -> StrictNestedDictionary:
     return StrictNestedDictionary(
         {
-            "version": __version__,
+            "version": __static__.__version__,
             "language": "",
             "location": [],
             "flags": ["python-format"],

--- a/src/i18n_tools/models/repository.py
+++ b/src/i18n_tools/models/repository.py
@@ -885,7 +885,7 @@ class Repository(StrictNestedDictionary):
         if type(value) != type(self[path]):
             raise TypeError(f"type of {value} must be {type(self[path])}")
 
-        if not self[path] and (value is not None or not value):
+        if self[path] or not value:
             raise ValueError(
                 f"Value '{value}' is not a valid value or {path} is not empty."
             )

--- a/src/i18n_tools/models/repository.py
+++ b/src/i18n_tools/models/repository.py
@@ -261,8 +261,6 @@ def _ensure_domain_presence(
 
 class Repository(StrictNestedDictionary):
     """
-    Repository
-    ----------
     High-level, structured container describing an i18n repository.
 
     The repository is split into several top-level sections:

--- a/src/i18n_tools/models/repository.py
+++ b/src/i18n_tools/models/repository.py
@@ -920,6 +920,36 @@ class Repository(StrictNestedDictionary):
 
         self[path] = value
 
+    def _empty_value_for(self, current: Any) -> Any:
+        """
+        Compute the empty/default placeholder value matching the type of
+        ``current``. Shared by :meth:`remove_value` and :meth:`clean_value`
+        (biface/i18n#28) — both reset a value to its type-appropriate empty
+        default, differing only in whether the current value is required
+        to be non-empty first.
+
+        :param current: The current value whose type determines the default.
+        :type current: Any
+        :return: An empty placeholder of the same type as ``current``
+                 (``None`` for unrecognised types).
+        :rtype: Any
+        """
+        if isinstance(current, StrictNestedDictionary):
+            return self._new_section({})
+        elif isinstance(current, dict):
+            return {}
+        elif isinstance(current, list):
+            return []
+        elif isinstance(current, str):
+            return ""
+        elif isinstance(current, bool):
+            return False
+        elif isinstance(current, int):
+            return 0
+        elif isinstance(current, float):
+            return 0.0
+        return None
+
     def remove_value(self, path: list[str]) -> None:
         """
         Remove a value from the repository by resetting it to its empty/default value.
@@ -942,26 +972,7 @@ class Repository(StrictNestedDictionary):
         if not current:
             raise ValueError(f"Value at {path} is already empty.")
 
-        # Compute an empty/default value according to current type
-        if isinstance(current, StrictNestedDictionary):
-            empty_val = self._new_section({})
-        elif isinstance(current, dict):
-            empty_val = {}
-        elif isinstance(current, list):
-            empty_val = []
-        elif isinstance(current, str):
-            empty_val = ""
-        elif isinstance(current, bool):
-            empty_val = False
-        elif isinstance(current, int):
-            empty_val = 0
-        elif isinstance(current, float):
-            empty_val = 0.0
-        else:
-            # Fallback to None for unknown types
-            empty_val = None
-
-        self[path] = empty_val
+        self[path] = self._empty_value_for(current)
 
     def clean_value(self, path: list[str]) -> None:
         """
@@ -977,22 +988,4 @@ class Repository(StrictNestedDictionary):
         if not self.paths().__contains__(path):
             raise KeyError(f"Path '{path}' does not exist in the repository.")
 
-        current = self[path]
-        if isinstance(current, StrictNestedDictionary):
-            empty_val = self._new_section({})
-        elif isinstance(current, dict):
-            empty_val = {}
-        elif isinstance(current, list):
-            empty_val = []
-        elif isinstance(current, str):
-            empty_val = ""
-        elif isinstance(current, bool):
-            empty_val = False
-        elif isinstance(current, int):
-            empty_val = 0
-        elif isinstance(current, float):
-            empty_val = 0.0
-        else:
-            empty_val = None
-
-        self[path] = empty_val
+        self[path] = self._empty_value_for(self[path])

--- a/src/i18n_tools/sync.py
+++ b/src/i18n_tools/sync.py
@@ -13,6 +13,7 @@ Key Responsibilities:
 from pathlib import Path
 from typing import Dict
 
+from .__static__ import I18N_TOOLS_TEMPLATE
 from .loaders.utils import _create_empty_file, _create_empty_json
 from .locale import validate_and_normalize_language_tags
 
@@ -47,20 +48,25 @@ def check_repository(tld: str, domains: Dict, languages: Dict):
         locales_path.mkdir(parents=True, exist_ok=True)
 
         for domain in domain_list:
+            # .pot is a per-domain template, shared across all languages
+            # (DD-12, repository.rst) — created once in templates/, not
+            # duplicated inside each language's LC_MESSAGES/.
+            templates_path = locales_path / I18N_TOOLS_TEMPLATE
+            templates_path.mkdir(parents=True, exist_ok=True)
+            pot_file = templates_path / f"{domain}.pot"
+            if not pot_file.exists():
+                _create_empty_file(str(pot_file))
+
             for lang in validated_languages:
                 lang_path = locales_path / lang / "LC_MESSAGES"
                 lang_path.mkdir(parents=True, exist_ok=True)
 
-                # Create .json, .pot, and .po files
+                # Create .json and .po files
                 json_file = lang_path / f"{domain}.json"
-                pot_file = lang_path / f"{domain}.pot"
                 po_file = lang_path / f"{domain}.po"
 
                 if not json_file.exists():
                     _create_empty_json(str(json_file))
-
-                if not pot_file.exists():
-                    _create_empty_file(str(pot_file))
 
                 if not po_file.exists():
                     _create_empty_file(str(po_file))

--- a/tests/01_loader/test_01_loader.py
+++ b/tests/01_loader/test_01_loader.py
@@ -160,6 +160,15 @@ class TestJsonOperations:
         with pytest.raises(FileNotFoundError):
             _load_json("/nonexistent/path")
 
+    def test_load_json_malformed_content_raises_json_decode_error(self, tmp_path):
+        """biface/i18n#26 — before this fix, a malformed-but-present JSON
+        file was mislabelled as FileNotFoundError (everything was caught
+        and masked). It must now surface as json.JSONDecodeError."""
+        corrupt_file = tmp_path / "corrupt.json"
+        corrupt_file.write_text("{not valid json at all", encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            _load_json(str(corrupt_file))
+
     def test_save_json(self, json_test_file):
         data = {"key": "new value"}
         _save_json(json_test_file, data)
@@ -506,6 +515,26 @@ class TestConfigFileOperations:
         with pytest.raises(Exception):
             _load_config_file("non-existent-path/i18n-tools.json")
             _save_config_file("non-existent-path/i18n-tools.json", {})
+
+    def test_load_config_file_yml_extension(self, tmp_path):
+        """biface/i18n#26 — .yml is accepted by __check_config_extension()
+        but _load_config_file()'s if/elif only matched ".yaml", silently
+        falling through and returning None. _save_config_file() already
+        handled ".yml" correctly; _load_config_file() must match it."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("key: value\n", encoding="utf-8")
+        result = _load_config_file(config_file)
+        assert result == {"key": "value"}
+
+    def test_load_config_file_malformed_content_raises_specific_error(self, tmp_path):
+        """biface/i18n#26 — well-formed extension, malformed content. Before
+        this fix, json.JSONDecodeError was caught and masked as a bare
+        Exception with a generic message. The specific, actionable
+        exception must now surface."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            _load_config_file(config_file)
 
 
 class TestRemoveFile:

--- a/tests/01_loader/test_02_loader.py
+++ b/tests/01_loader/test_02_loader.py
@@ -779,7 +779,7 @@ class TestVerifyRepository:
                 "fsm_tools/turing",
                 "model",
                 False,
-                IndexError,
+                ValueError,
                 "The target domain 'model' is not registered in the repository",
             ),
             (
@@ -787,7 +787,7 @@ class TestVerifyRepository:
                 "information",
                 False,
                 ValueError,
-                "The target module 'fsm-tools/turing' is not registered in the repository",
+                "The target module fsm-tools/turing is not registered in the repository",
             ),
         ],
     )
@@ -994,7 +994,7 @@ class TestTranslationSet:
                 ValueError,
                 None,
             ),
-            ("fsm_tools", "usages", {}, False, [], IndexError, ""),
+            ("fsm_tools", "usages", {}, False, [], ValueError, ""),
         ],
     )
     def tests_add_translation_set(
@@ -1137,7 +1137,7 @@ class TestTranslationSet:
                 None,
                 None,
             ),
-            ("fsm_tools", "usages", {}, False, [], IndexError, ""),
+            ("fsm_tools", "usages", {}, False, [], ValueError, ""),
             (
                 "fsm_tools",
                 "usage",
@@ -1211,7 +1211,7 @@ class TestTranslationSet:
                 None,
                 None,
             ),
-            ("fsm_tools", "usages", {}, False, [], IndexError, ""),
+            ("fsm_tools", "usages", {}, False, [], ValueError, ""),
         ],
     )
     def tests_remove_translation_set(

--- a/tests/01_loader/test_03_loader.py
+++ b/tests/01_loader/test_03_loader.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+import yaml
 
 from i18n_tools.loaders.loader import load_book
 
@@ -28,12 +29,26 @@ def _write_i18t(directory, data, name="usage.json.i18t"):
     return str(file)
 
 
+def _write_yaml_i18t(directory, data, name="usage.yaml.i18t"):
+    file = directory / name
+    file.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return str(file)
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
 
 class TestLoadBook:
+    def test_load_book_detects_yaml_format(self, tmp_path):
+        """biface/i18n#67 — un fichier .yaml.i18t doit être chargé en YAML,
+        pas toujours en JSON. Avant #67, load_book() ignorait le format
+        détecté et appelait systématiquement _load_json()."""
+        result = load_book(_write_yaml_i18t(tmp_path, VALID_DATA))
+        assert set(result.keys()) == {"10001", "10002"}
+        assert result["10001"]["messages"] == [["Un message"], ["Des messages"]]
+
     def test_load_book_returns_filtered_dict(self, tmp_path):
         """Cas nominal : retourne un dict avec les bons msgids, clés réservées exclues."""
         result = load_book(_write_i18t(tmp_path, VALID_DATA))

--- a/tests/01_loader/test_03_loader.py
+++ b/tests/01_loader/test_03_loader.py
@@ -1,11 +1,25 @@
-"""Tests for load_book() — loaders/loader.py (A-01)."""
+"""Tests for loaders/loader.py (biface/i18n#31).
 
+load_book() was already covered (A-01). load_locale_json(),
+aggregate_locale_json(), save_locale_json(), and
+save_aggregated_locale_json() had zero coverage despite #31 claiming
+the whole loaders layer had none — verified by coverage measurement
+(loader.py was at 43%, the rest of the loaders layer was already at
+91-94%)."""
+
+import gzip
 import json
 
 import pytest
 import yaml
 
-from i18n_tools.loaders.loader import load_book
+from i18n_tools.loaders.loader import (
+    aggregate_locale_json,
+    load_book,
+    load_locale_json,
+    save_aggregated_locale_json,
+    save_locale_json,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,3 +87,120 @@ class TestLoadBook:
         """Matrice mal formée → ValueError."""
         with pytest.raises(ValueError):
             load_book(_write_i18t(tmp_path, INVALID_DATA))
+
+
+class TestLoadLocaleJson:
+    def test_load_locale_json_valid(self, tmp_path):
+        file = tmp_path / "domain.json"
+        file.write_text(json.dumps(VALID_DATA), encoding="utf-8")
+        result = load_locale_json(str(file))
+        assert result == VALID_DATA
+
+    def test_load_locale_json_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_locale_json(str(tmp_path / "missing.json"))
+
+    def test_load_locale_json_integrity_error(self, tmp_path):
+        file = tmp_path / "domain.json"
+        file.write_text(json.dumps(INVALID_DATA), encoding="utf-8")
+        with pytest.raises(ValueError, match="Integrity check failed"):
+            load_locale_json(str(file))
+
+
+class TestSaveLocaleJson:
+    def test_save_locale_json(self, tmp_path):
+        file = tmp_path / "domain.json"
+        save_locale_json(str(file), VALID_DATA)
+        assert json.loads(file.read_text(encoding="utf-8")) == VALID_DATA
+
+
+class TestAggregateLocaleJson:
+    def test_aggregate_locale_json(self, tmp_path):
+        module = "module_a"
+        domain = "usage"
+        locales = tmp_path / module / "locales"
+        (locales / "fr").mkdir(parents=True)
+        (locales / "fr-FR").mkdir(parents=True)
+
+        fr_data = {"10001": [["Message"], ["Messages"]]}
+        fr_fr_data = {"10002": [["Autre message"], ["Autres messages"]]}
+        (locales / "fr" / f"{domain}.json").write_text(
+            json.dumps(fr_data), encoding="utf-8"
+        )
+        (locales / "fr-FR" / f"{domain}.json").write_text(
+            json.dumps(fr_fr_data), encoding="utf-8"
+        )
+
+        structure = {"base": str(tmp_path), "modules": [module]}
+        domains = {module: [domain]}
+        languages = {"fr": ["fr-FR"]}
+
+        result = aggregate_locale_json(structure, domains, languages)
+
+        assert result[module][domain]["fr"] == fr_data
+        assert result[module][domain]["fr-FR"] == fr_fr_data
+
+    def test_aggregate_locale_json_missing_variant_is_skipped(self, tmp_path):
+        """A variant with no matching file on disk is simply absent from
+        the result — aggregate_locale_json() does not raise."""
+        module = "module_a"
+        domain = "usage"
+        locales = tmp_path / module / "locales"
+        (locales / "fr").mkdir(parents=True)
+        fr_data = {"10001": [["Message"], ["Messages"]]}
+        (locales / "fr" / f"{domain}.json").write_text(
+            json.dumps(fr_data), encoding="utf-8"
+        )
+        # No "fr-FR" directory/file created on purpose.
+
+        structure = {"base": str(tmp_path), "modules": [module]}
+        domains = {module: [domain]}
+        languages = {"fr": ["fr-FR"]}
+
+        result = aggregate_locale_json(structure, domains, languages)
+
+        assert result[module][domain]["fr"] == fr_data
+        assert "fr-FR" not in result[module][domain]
+
+
+class TestSaveAggregatedLocaleJson:
+    def test_save_aggregated_locale_json_creates_gzipped_files(self, tmp_path):
+        aggregated_data = {
+            "module_a": {
+                "usage": {"fr": {"10001": [["Message"], ["Messages"]]}},
+            }
+        }
+
+        save_aggregated_locale_json(aggregated_data, str(tmp_path))
+
+        module_dir = tmp_path / "module_a"
+        locales = module_dir / "locales"
+
+        domain_gz = locales / "usage.json.gz"
+        assert domain_gz.exists()
+        assert not (locales / "usage.json").exists()
+        with gzip.open(domain_gz, "rt", encoding="utf-8") as f:
+            assert json.load(f) == {"fr": {"10001": [["Message"], ["Messages"]]}}
+
+        # The module-level aggregate is written next to the module
+        # directory itself, not inside locales/.
+        module_gz = module_dir / "module_a.json.gz"
+        assert module_gz.exists()
+        assert not (module_dir / "module_a.json").exists()
+        with gzip.open(module_gz, "rt", encoding="utf-8") as f:
+            assert json.load(f) == aggregated_data["module_a"]
+
+    def test_save_aggregated_locale_json_handles_submodules(self, tmp_path):
+        aggregated_data = {
+            "module_a/sub": {
+                "usage": {"fr": {"10001": [["Message"], ["Messages"]]}},
+            }
+        }
+
+        save_aggregated_locale_json(aggregated_data, str(tmp_path))
+
+        module_dir = tmp_path / "module_a" / "sub"
+        locales = module_dir / "locales"
+        assert (locales / "usage.json.gz").exists()
+        # Submodule aggregate is named after the last path segment ("sub").
+        assert (module_dir / "sub.json.gz").exists()

--- a/tests/02_models/test_00_respository.py
+++ b/tests/02_models/test_00_respository.py
@@ -1946,3 +1946,93 @@ class TestRepositoryCleanTranslator:
     def test_clean_translator(self, repository_fixture):
         repository_fixture.clean_translators()
         assert len(repository_fixture.translators) == 0
+
+
+class TestRepositoryAddUpdateRemoveCleanValue:
+    """biface/i18n#29 — add_value()'s guard was a tautology
+    (`value is not None or not value` is always True), so the condition
+    reduced to `not self[path]`: it always raised on a genuinely empty
+    path (add_value could never succeed in its intended case) and always
+    silently overwrote an already-set path, including with None/"" — the
+    bug reported in #29.
+
+    No test previously covered add_value/remove_value/clean_value despite
+    #24 ("Repository has no tests") being marked closed.
+    """
+
+    def test_add_value_succeeds_on_empty_path(self, repository_fixture):
+        path = ["paths", "config"]
+        repository_fixture.remove_value(path)  # ensure empty first
+        assert repository_fixture[path] == ""
+
+        repository_fixture.add_value(path, "restored-config-path")
+        assert repository_fixture[path] == "restored-config-path"
+
+    def test_add_value_rejects_empty_or_none_on_empty_path(self, repository_fixture):
+        path = ["paths", "config"]
+        repository_fixture.remove_value(path)
+        assert repository_fixture[path] == ""
+
+        with pytest.raises(ValueError, match=re.escape(f"{path} is not empty")):
+            repository_fixture.add_value(path, "")
+
+    def test_add_value_rejects_when_path_already_set(self, repository_fixture):
+        path = ["paths", "backup"]
+        assert repository_fixture[path]  # sanity: starts non-empty
+
+        # Before the fix: this silently overwrote the existing value with
+        # "" — the bug from #29. It must now raise instead.
+        original = repository_fixture[path]
+        with pytest.raises(ValueError, match=re.escape(f"{path} is not empty")):
+            repository_fixture.add_value(path, "")
+        assert repository_fixture[path] == original  # untouched
+
+        with pytest.raises(ValueError, match=re.escape(f"{path} is not empty")):
+            repository_fixture.add_value(path, "some-other-value")
+        assert repository_fixture[path] == original  # still untouched
+
+    def test_update_value_requires_existing_value(self, repository_fixture):
+        path = ["paths", "root"]
+        original = repository_fixture[path]
+        assert original
+
+        repository_fixture.update_value(path, "updated-root-path")
+        assert repository_fixture[path] == "updated-root-path"
+
+        repository_fixture.remove_value(path)
+        with pytest.raises(
+            ValueError, match=re.escape(f"Cannot update empty value at {path}")
+        ):
+            repository_fixture.update_value(path, "anything")
+
+        # restore for any later test relying on this class-scoped fixture
+        repository_fixture.add_value(path, original)
+
+    def test_remove_value_then_rejects_on_already_empty(self, repository_fixture):
+        path = ["languages", "fallback"]
+        original = repository_fixture[path]
+        assert original
+
+        repository_fixture.remove_value(path)
+        assert repository_fixture[path] == ""
+
+        with pytest.raises(ValueError, match=re.escape(f"{path} is already empty")):
+            repository_fixture.remove_value(path)
+
+        repository_fixture.add_value(path, original)
+
+    def test_clean_value_resets_regardless_of_current_state(self, repository_fixture):
+        path = ["languages", "fallback"]
+        original = repository_fixture[path]
+        assert original
+
+        # clean_value works even though the path is currently non-empty —
+        # unlike remove_value, it has no "already empty" guard.
+        repository_fixture.clean_value(path)
+        assert repository_fixture[path] == ""
+
+        # and again on an already-empty path, without raising
+        repository_fixture.clean_value(path)
+        assert repository_fixture[path] == ""
+
+        repository_fixture.add_value(path, original)

--- a/tests/02_models/test_01_book.py
+++ b/tests/02_models/test_01_book.py
@@ -596,6 +596,23 @@ class TestBookAttributes:
         book.add_format("yaml")
         assert book.format == "yaml"
 
+    def test_constructor_and_setters_validate_format_consistently(self):
+        """biface/i18n#66 — before this fix, Book(format=...) accepted any
+        value silently (no call to the format validator), while
+        add_format()/update_format() raised ValueError on the same input.
+        All three now go through build_book_filename() and must behave
+        identically."""
+        with pytest.raises(ValueError, match="Unknown format 'banana'"):
+            Book(domain="d", language="fr-FR", format="banana")
+
+        book = Book(domain="d", language="fr-FR")
+        with pytest.raises(ValueError, match="Unknown format 'banana'"):
+            book.update_format("banana")
+
+        book.remove_format()
+        with pytest.raises(ValueError, match="Unknown format 'banana'"):
+            book.add_format("banana")
+
 
 class TestBookUpdate:
     def test_update_language_success_on_empty_book(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,12 +387,12 @@ def patch_validate_api_url(is_main_branch):
     else:
         # On other branches, use the mock function
         # Patch both the direct import in api module and the import in config module
-        with mock.patch(
-            "i18n_tools.api.validate_api_url", mock_validate_api_url
-        ), mock.patch(
-            "i18n_tools.config.validate_api_url", mock_validate_api_url
-        ), mock.patch(
-            "i18n_tools.models.repository.validate_api_url", mock_validate_api_url
+        with (
+            mock.patch("i18n_tools.api.validate_api_url", mock_validate_api_url),
+            mock.patch("i18n_tools.config.validate_api_url", mock_validate_api_url),
+            mock.patch(
+                "i18n_tools.models.repository.validate_api_url", mock_validate_api_url
+            ),
         ):
             yield
 
@@ -419,7 +419,8 @@ def patch_validate_email(is_main_branch):
     else:
         # On other branches, use the mock function
         # Patch both the direct import in email_validator module and the import in config module
-        with mock.patch(
-            "email_validator.validate_email", mock_validate_email
-        ), mock.patch("i18n_tools.config.validate_email", mock_validate_email):
+        with (
+            mock.patch("email_validator.validate_email", mock_validate_email),
+            mock.patch("i18n_tools.config.validate_email", mock_validate_email),
+        ):
             yield

--- a/tests/test_04_sync.py
+++ b/tests/test_04_sync.py
@@ -1,0 +1,61 @@
+"""Tests for check_repository() — sync.py (biface/i18n#30).
+
+No test previously covered sync.py at all.
+"""
+
+import pytest
+
+from i18n_tools.sync import check_repository
+
+
+class TestCheckRepository:
+    def test_pot_created_once_per_domain_in_templates(self, tmp_path):
+        """The bug: .pot was created inside each language's LC_MESSAGES/
+        (duplicated per language) instead of once per domain in
+        templates/ (DD-12, repository.rst)."""
+        domains = {"module_a": ["usage"]}
+        languages = {
+            "source": "en",
+            "hierarchy": {"en": ["en-US"], "fr": ["fr-FR"]},
+        }
+
+        check_repository(str(tmp_path), domains, languages)
+
+        templates_dir = tmp_path / "module_a" / "locales" / "templates"
+        assert (templates_dir / "usage.pot").exists()
+
+    def test_pot_not_duplicated_in_lc_messages(self, tmp_path):
+        domains = {"module_a": ["usage"]}
+        languages = {
+            "source": "en",
+            "hierarchy": {"en": ["en-US"], "fr": ["fr-FR"]},
+        }
+
+        check_repository(str(tmp_path), domains, languages)
+
+        for lang in ("en", "en-US", "fr-FR"):
+            lc_messages = tmp_path / "module_a" / "locales" / lang / "LC_MESSAGES"
+            assert not (lc_messages / "usage.pot").exists()
+
+    def test_json_and_po_created_per_language(self, tmp_path):
+        domains = {"module_a": ["usage"]}
+        languages = {
+            "source": "en",
+            "hierarchy": {"en": ["en-US"], "fr": ["fr-FR"]},
+        }
+
+        check_repository(str(tmp_path), domains, languages)
+
+        for lang in ("en", "en-US", "fr-FR"):
+            lc_messages = tmp_path / "module_a" / "locales" / lang / "LC_MESSAGES"
+            assert (lc_messages / "usage.json").exists()
+            assert (lc_messages / "usage.po").exists()
+
+    def test_rejects_relative_tld(self, tmp_path):
+        with pytest.raises(ValueError, match="must be absolute"):
+            check_repository("relative/path", {}, {"source": "en", "hierarchy": {}})
+
+    def test_rejects_nonexistent_tld(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            check_repository(str(missing), {}, {"source": "en", "hierarchy": {}})

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ description = Check code formatting with black
 deps =
     black
 commands =
-    black --check src
+    black --target-version py310 --check src
 
 [testenv:fix]
 description = Auto-fix formatting of package code (tests are excludes) issues using Black and isort
@@ -70,7 +70,7 @@ deps =
     -r requirements.test.txt
 commands =
 # Fix formatting
-    black src tests
+    black --target-version py310 src tests
     isort src tests
 # Security checks (B202 : Tarfile traversal are controlled with _non_traversal_path in loaders.py)
     bandit -r src -s B202


### PR DESCRIPTION
## Summary

Closes out the v0.4.0 milestone: resolves the circular-import/layering issues blocking the public API, harmonizes error handling, fixes loader/sync bugs, removes dead code, raises loaders-layer test coverage from 87% to 94%, and delivers the project-level documentation set (README, LICENSE, Code of Conduct, CHANGELOG, Sphinx/Furo init).

## Type of change

- [x] Bug fix
- [x] Refactoring
- [x] Tests
- [x] Documentation

## Related issues

Closes #63, #64, #65, #68, #67, #66, #29, #28, #27, #26, #30, #31, #53, #34

## List of changes

**Architecture / bug fixes**
- Resolved the circular import between `i18n_tools.__init__` and 3 internal modules; `Config` exposed in the public API for the first time (#64)
- `Repository.add_value()`: fixed a tautological guard that always rejected valid adds and always overwrote existing values (#29)
- `loader.load_book()`: now detects file format instead of always loading as JSON (#67) — also removed a regressed bug (#8, originally  fixed in v0.1.x) carried by 9 dead duplicate functions
- `loaders/utils.py`: 11 functions no longer mask every failure as `FileNotFoundError`; `.yml` config files no longer silently fail (#26)
- `_verify_target_domain`: exception type now matches its own docstring instead of contradicting it (#27)
- `sync.py`: `.pot` created once per domain in `templates/`, not duplicated per language (#30)
- `Book` (`corpus.py`) no longer imports `loaders.utils` directly (#66)
- `pyproject.toml`: fixed wrong project URLs, duplicate dependency (#63)

**Tests**
- `loaders/loader.py` coverage: 43% → 100%; loaders layer overall:  87% → 94% (#31)
- First tests for `sync.py`, and for `Repository.add_value`/ `update_value`/`remove_value`/`clean_value` (#29, #30)

**Documentation**
- `README.md`/`README.fr.md` split from a single bilingual file;
  roadmap refreshed
- `license.md`/`licence.md`, `CODE_OF_CONDUCT.md`/`CODE_DE_CONDUITE.md`:
  corrected copy-paste leftovers from `ndict-tools` (#53)
- New `CHANGELOG.md`
- Sphinx/Furo documentation initialized; `make html` succeeds with
  zero warnings (#34)
- Design decisions corrected or updated :
  - #64 
  - #55

**Deferred to v0.6.x** (tracked separately): `CONTRIBUTING.md` (depends on the `uv`/`tox-uv`/`basedpyright` migration, DD-36), GitHub Pages documentation deployment on tag.

## Testing

`tox -e local`: 1073 passed / 41 skipped / 0 failed.

## Documentation checklist

- [x] `DESIGN_DECISIONS.md` updated for every non-trivial decision in this PR
- [x] `CHANGELOG.md` updated
- [x] Project-level documents (README, LICENSE, CoC) corrected and split

## Notes for the reviewer

This branch surfaced several pre-existing inaccuracies in already-closed issues (#19, #24, #56) and in `DESIGN_DECISIONS.md` (`loaders/repository.py` wrongly marked for deletion in #64) — corrected in place rather than silently worked around. See individual commit messages and issue comments for details.