### PR TITLE
v0.5.0 — Architecture & layering hardening

### DIFF
--- a/src/i18n_tools/api.py
+++ b/src/i18n_tools/api.py
@@ -12,6 +12,24 @@ import requests
 import validators
 
 
+def validate_url_format(url: str) -> dict:
+    """
+    Validates the syntactic format of a URL — no network call.
+
+    Structural-only check intended for synchronous model methods that must
+    never perform I/O (e.g. Repository.add_translator()). The full
+    availability check remains validate_api_url(), to be invoked explicitly
+    and separately (DD-14c, DD-NN, KI-01).
+
+    :param url: The URL to validate.
+    :return: A dictionary with the URL and an error message if the format is invalid.
+    """
+    result = {"url": url, "error": None}
+    if not validators.url(url):
+        result["error"] = f"URL '{url}' is not a valid format."
+    return result
+
+
 def validate_api_url(url: str, timeout: int = 5) -> dict:
     """
     Validates a URL by checking its format and availability.
@@ -31,9 +49,10 @@ def validate_api_url(url: str, timeout: int = 5) -> dict:
         "error": None,
     }
 
-    # Validate URL format — message is already English (uses validators library)
-    if not validators.url(url):
-        result["error"] = f"URL '{url}' is not a valid format."
+    # Format check delegated to validate_url_format() — single source of truth
+    format_check = validate_url_format(url)
+    if format_check["error"]:
+        result["error"] = format_check["error"]
         return result
 
     # Check URL accessibility

--- a/src/i18n_tools/config.py
+++ b/src/i18n_tools/config.py
@@ -197,8 +197,10 @@ class Config(metaclass=Singleton):
         else:
             self.application = _setup_configuration()
 
-        # TODO(ndict-tools-v1.2.0): replace direct StrictNestedDictionary({}) construction
-        # with Repository delegation once ndict-tools v1.2.0 is available. See #17 on GitHub.
+        # _email_index spans both self.package and self.application — it is
+        # config-level cross-repository state, not data modelled by a single
+        # Repository instance, so it intentionally stays a plain
+        # StrictNestedDictionary rather than being delegated (DD-NN).
         self._email_index = StrictNestedDictionary({})
         self._current_config = "application"
 
@@ -528,18 +530,16 @@ class Config(metaclass=Singleton):
                     author = self.application[["authors", existing_uuid]]
         else:
             author_id = str(uuid4())
-            author = StrictNestedDictionary(
-                {
-                    "first_name": first_name,
-                    "last_name": last_name,
-                    "email": email,
-                    "url": url,
-                    "languages": normalized_languages,
-                }
-            )
+            author = {
+                "first_name": first_name,
+                "last_name": last_name,
+                "email": email,
+                "url": url,
+                "languages": normalized_languages,
+            }
             self._email_index[email] = author_id
 
-        self.__getattribute__(self._current_config)[["authors", author_id]] = author
+        self.__getattribute__(self._current_config).add_author(author_id, author)
 
     def get_author(self, index: str) -> Optional[dict]:
         """
@@ -714,9 +714,7 @@ class Config(metaclass=Singleton):
             raise KeyError(f"Translator '{name}' already exists.")
 
         # 4. Add the translator to the dictionary
-        current_repository["translators"][name] = StrictNestedDictionary(
-            translator_data
-        )
+        current_repository.add_translator(name, translator_data)
 
     def get_translator(self, name: str) -> StrictNestedDictionary:
         """
@@ -808,12 +806,8 @@ class Config(metaclass=Singleton):
             translators.pop(name)
 
             # Ensure the translators dictionary remains a valid empty dictionary if no translators remain
-            # TODO(ndict-tools-v1.2.0): replace direct StrictNestedDictionary({}) construction
-            # with Repository delegation once ndict-tools v1.2.0 is available. See #17.
             if not translators:
-                self.__getattribute__(self._current_config)["translators"] = (
-                    StrictNestedDictionary({})
-                )
+                self.__getattribute__(self._current_config).clean_translators()
 
             return True
 

--- a/src/i18n_tools/config.py
+++ b/src/i18n_tools/config.py
@@ -124,6 +124,7 @@ from .__static__ import (
 from .api import validate_api_url
 from .loaders.handler import build_path, file_exists, load_config, save_config
 from .locale import validate_and_normalize_language_tags
+from .models.author import Authors
 from .models.repository import Repository
 from .patterns import Singleton
 
@@ -140,9 +141,6 @@ class Config(metaclass=Singleton):
         package (StrictNestedDictionary): A nested dictionary which contains the default i18n-tools package translation repository configuration settings.
 
         application (StrictNestedDictionary): A nested dictionary which contains the default application translation repository configuration settings.
-
-        _email_index (StrictNestedDictionary):
-            An internal index for tracking authors by email address.
 
         _current_config (str): store the current configuration to manage.
     """
@@ -197,11 +195,6 @@ class Config(metaclass=Singleton):
         else:
             self.application = _setup_configuration()
 
-        # _email_index spans both self.package and self.application — it is
-        # config-level cross-repository state, not data modelled by a single
-        # Repository instance, so it intentionally stays a plain
-        # StrictNestedDictionary rather than being delegated (DD-NN).
-        self._email_index = StrictNestedDictionary({})
         self._current_config = "application"
 
     def load(self):
@@ -227,17 +220,6 @@ class Config(metaclass=Singleton):
                 current_config[key].update(value)
             else:
                 raise AttributeError(f"Unknown configuration key '{key}' in setup.")
-
-        # Rebuild email index
-
-        self._email_index.update(
-            {
-                author_data["email"]: author_id
-                for author_id, author_data in self.__getattribute__(
-                    self._current_config
-                )["authors"].items()
-            }
-        )
 
     def save(self) -> None:
         """
@@ -513,21 +495,23 @@ class Config(metaclass=Singleton):
         except Exception as e:
             raise e
 
-        if email in self._email_index:
-            existing_uuid = self._email_index[email]
-            if (
-                existing_uuid
-                in self.__getattribute__(self._current_config)["authors"].keys()
-            ):
+        current_repository = self.__getattribute__(self._current_config)
+        other_repository = (
+            self.application if self._current_config == "package" else self.package
+        )
+
+        existing_uuid = Authors.get_id_by_email(
+            current_repository, email
+        ) or Authors.get_id_by_email(other_repository, email)
+
+        if existing_uuid:
+            if existing_uuid in current_repository["authors"].keys():
                 raise KeyError(
                     f"Email address '{email}' is already registered in the authors dictionary (UUID: {existing_uuid})."
                 )
             else:
                 author_id = existing_uuid
-                if self._current_config == "application":
-                    author = self.package[["authors", existing_uuid]]
-                else:
-                    author = self.application[["authors", existing_uuid]]
+                author = other_repository[["authors", existing_uuid]]
         else:
             author_id = str(uuid4())
             author = {
@@ -537,9 +521,8 @@ class Config(metaclass=Singleton):
                 "url": url,
                 "languages": normalized_languages,
             }
-            self._email_index[email] = author_id
 
-        self.__getattribute__(self._current_config).add_author(author_id, author)
+        current_repository.add_author(author_id, author)
 
     def get_author(self, index: str) -> Optional[dict]:
         """
@@ -574,7 +557,7 @@ class Config(metaclass=Singleton):
             raise ValueError(f"Invalid email format: {e}")
 
         # Search by email in the email index
-        author_id = self._email_index.get(index)
+        author_id = Authors.get_id_by_email(current_config, index)
         if author_id:
             return current_config[["authors", author_id]]
 
@@ -589,17 +572,14 @@ class Config(metaclass=Singleton):
         :return: True if the author was successfully removed, False if not found.
         :raises ValueError: If the email format is invalid or the index is neither a UUID nor a valid email.
         """
+        current_repository = self.__getattribute__(self._current_config)
+
         # Check if the input is a valid UUID
         try:
             uuid_obj = UUID(index)
             # Remove by UUID if it exists
-            if index in self.__getattribute__(self._current_config)["authors"]:
-                # Remove the author
-                author = self.__getattribute__(self._current_config)["authors"].pop(
-                    index
-                )
-                # Remove from the email index
-                self._email_index.pop(author["email"], None)
+            if index in current_repository["authors"]:
+                current_repository.remove_author(index)
                 return True
             else:
                 return False  # UUID not found
@@ -613,12 +593,10 @@ class Config(metaclass=Singleton):
         except EmailNotValidError as e:
             raise ValueError(f"Invalid email format: {e}")
 
-        # Search by email in the email index
-        author_id = self._email_index.get(index)
+        # Search by email
+        author_id = Authors.get_id_by_email(current_repository, index)
         if author_id:
-            # Remove the author and the email index entry
-            self.__getattribute__(self._current_config)["authors"].pop(author_id, None)
-            self._email_index.pop(index, None)
+            current_repository.remove_author(author_id)
             return True
 
         # If no match found, return False
@@ -781,15 +759,10 @@ class Config(metaclass=Singleton):
         # Validate updates against the existing translator structure
         validate_structure(existing_translator, updates)
 
-        # Apply the updates
-        def apply_updates(target: dict, source: dict):
-            for key, value in source.items():
-                if isinstance(value, dict):
-                    apply_updates(target[key], value)
-                else:
-                    target[key] = value
-
-        apply_updates(existing_translator, updates)
+        # Apply the updates — delegated to Repository.update_translator(), which
+        # re-validates structurally; harmless here since validate_structure()
+        # above already guarantees the updates are well-formed (DD-NN/#25).
+        current_repository.update_translator(name, updates)
 
     def remove_translator(self, name: str) -> bool:
         """

--- a/src/i18n_tools/loaders/loader.py
+++ b/src/i18n_tools/loaders/loader.py
@@ -1,28 +1,78 @@
 """
 This module handles the file operations necessary for internationalization
-(i18n) tools. It focuses on loading and saving configuration files and
-managing `.pot` files for translation projects.
+(i18n) tools. It focuses on loading and saving configuration files,
+managing `.pot` files for translation projects, and orchestrating
+repository-wide operations (scaffolding, archiving, aggregation, and
+translation-set CRUD).
 
 **Key Features:**
     - Load and save configuration files in YAML, TOML, or JSON formats.
     - Search for configuration files in application directories.
     - Load and save `.pot` files, including metadata headers and translation entries.
+    - Build, verify, archive, and restore a whole repository.
+    - Add, update, remove, and aggregate translation sets across modules,
+      domains, and languages.
 
+`loader.py` is the sole bridge between `/models/` and the rest of
+`/loaders/` (DD-06, DD-NN). `handler.py` and `utils.py` must never be
+imported directly from `/models/` — models talk only to this module,
+which can in turn be used standalone (returning raw dicts, no model
+objects required) or together with model instances (e.g. ``Book``,
+``Repository``).
 """
 
+import tarfile
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
+from ndict_tools import StrictNestedDictionary
+
+from i18n_tools.__static__ import (
+    I18N_TOOLS_BACKUP,
+    I18N_TOOLS_CONFIG,
+    I18N_TOOLS_LOCALE,
+    I18N_TOOLS_MESSAGES,
+    I18N_TOOLS_TEMPLATE,
+)
+from i18n_tools.loaders.handler import (
+    _verify_available_languages,
+    _verify_paths_and_modules,
+    _verify_target_domain,
+)
 from i18n_tools.loaders.handler import build_book_filename as _build_book_filename
-from i18n_tools.loaders.handler import check_json_integrity
+from i18n_tools.loaders.handler import (
+    build_path,
+    build_translation_lang_files,
+    check_json_integrity,
+    create_catalog,
+    create_dictionary,
+    create_directory,
+    create_template,
+    dump_dictionary,
+    fetch_dictionary,
+)
+from i18n_tools.loaders.handler import file_exists as _file_exists
+from i18n_tools.loaders.handler import is_absolute_path as _is_absolute_path
+from i18n_tools.loaders.handler import (
+    normalize_module_identifier as _normalize_module_identifier,
+)
+from i18n_tools.loaders.handler import (
+    update_dictionary,
+)
 from i18n_tools.loaders.utils import (
+    _build_dictionary_path,
+    _check_domains,
+    _check_module,
     _create_gzip,
     _detect_format,
+    _exist_path,
     _load_by_format,
     _load_json,
+    _non_traversal_path,
     _save_by_format,
     _save_json,
 )
+from i18n_tools.locale import get_all_languages
 
 
 def load_locale_json(file_path: str) -> Dict[str, Any]:
@@ -131,6 +181,12 @@ def aggregate_locale_json(
     """
     Aggregate JSON locale files based on the given structure, domains, and languages.
 
+    Distinct from :func:`aggregate_dictionaries`: this function works from
+    generic, caller-supplied parameters (no ``Repository`` instance, no
+    embedded metadata) and reads files directly from disk by path. Kept
+    alongside it as a separate, legitimate responsibility — not a
+    duplicate (DD-NN, #69).
+
     :param structure: Dictionary containing 'base' path and list of 'modules'.
     :type structure: Dict[str, Any]
     :param domains: Dictionary where keys are module names and values are lists of domains.
@@ -189,6 +245,10 @@ def save_aggregated_locale_json(
     Save the aggregated locale JSON data as gzipped files for each domain in the locales directory,
     and create a gzipped file for the entire module or sub-module at the base of its directory.
 
+    Companion to :func:`aggregate_locale_json` — see that function's
+    docstring for why it is kept distinct from :func:`aggregate_dictionaries`
+    (DD-NN, #69).
+
     :param aggregated_data: The aggregated dictionary of locale data.
     :type aggregated_data: dict
     :param base_path: The base path where the locales directories are located.
@@ -235,3 +295,488 @@ def build_book_filename(domain: str, fmt: Union[str, None] = None) -> Tuple[str,
     :raises ValueError: If ``fmt`` is not a recognised translation format.
     """
     return _build_book_filename(domain, fmt)
+
+
+def file_exists(file_path: str) -> bool:
+    """
+    Pass-through to :func:`i18n_tools.loaders.handler.file_exists`.
+
+    Kept here so that `Repository` (`models/repository.py`) only ever talks
+    to `loader.py`, consistent with the `build_book_filename` pattern
+    (DD-06, DD-NN) — never directly to `handler.py`.
+
+    :param file_path: The path to check.
+    :type file_path: str
+    :return: True if the path exists, False otherwise.
+    :rtype: bool
+    """
+    return _file_exists(file_path)
+
+
+def is_absolute_path(path: str) -> bool:
+    """
+    Pass-through to :func:`i18n_tools.loaders.handler.is_absolute_path`.
+
+    Kept here so that `Repository` (`models/repository.py`) only ever talks
+    to `loader.py`, consistent with the `build_book_filename` pattern
+    (DD-06, DD-NN) — never directly to `handler.py`.
+
+    :param path: The path to check.
+    :type path: str
+    :return: True if the path is absolute, False otherwise.
+    :rtype: bool
+    """
+    return _is_absolute_path(path)
+
+
+def normalize_module_identifier(path: str) -> str:
+    """
+    Pass-through to :func:`i18n_tools.loaders.handler.normalize_module_identifier`.
+
+    Kept here so that `Repository` (`models/repository.py`) only ever talks
+    to `loader.py`, consistent with the `build_book_filename` pattern
+    (DD-06, DD-NN) — never directly to `handler.py`.
+
+    :param path: A module identifier or an absolute file-system path.
+    :type path: str
+    :return: The normalized module identifier.
+    :rtype: str
+    """
+    return _normalize_module_identifier(path)
+
+
+def _update_json_translations(existing_translations: Dict, translation_data: Dict):
+    """
+    Update translations in JSON with new data.
+
+    This function merges new translation data into the existing translations.
+    If a message ID already exists, it extends the existing translations with the new data.
+
+    :param existing_translations: Dictionary of existing translations.
+    :param translation_data: Dictionary of new translation data to be merged.
+    :return: Updated dictionary of translations.
+    """
+    for msgid, msgstr_list in translation_data.items():
+        existing_translations[msgid] = msgstr_list
+    return existing_translations
+
+
+def create_module_archive(
+    repository: StrictNestedDictionary, module: str, archive_name: str
+) -> None:
+    """
+    Create a tar.gz archive of a module's contents, including all subdirectories and files,
+    by identifying the top-level module from the given module/package path.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :param module: The module or module/package path (e.g., "mod-1/pkg-1").
+    :type module: str
+    :param archive_name: The name of the archive file.
+    :type archive_name: str
+    :return: Nothing
+    :rtype: None
+    """
+
+    # Identify the top-level module from the given module path
+    # This is done by splitting the module path and taking the first part
+    # For example, if module is "mod-1/pkg-1", top_level_module will be "mod-1"
+    top_level_module = module.split("/")[0]
+
+    # Build the path to backup directory as <
+    archive_path = build_path(repository[["paths", "repository"]], top_level_module)
+
+    # Construct the full path to the top-level module
+    # This is the directory that will be archived
+    backup_path = build_path(
+        repository[["paths", "repository"]],
+        top_level_module,
+        I18N_TOOLS_LOCALE,
+        I18N_TOOLS_CONFIG,
+        I18N_TOOLS_BACKUP,
+    )
+
+    # Construct the path for the archive file
+    # The archive will be created in the root_path directory with the given archive_name
+    archive = backup_path + f"/{archive_name}.tar.gz"
+
+    # Open the archive file in write mode with gzip compression
+    with tarfile.open(archive, "w:gz") as tar:
+        # Add the top-level module to the archive
+        # The arcname parameter ensures that the directory structure is preserved in the archive
+        # This means the archive will contain the top-level module directory and all its contents
+        tar.add(archive_path, arcname=top_level_module)
+
+
+def restore_module_from_archive(
+    repository: StrictNestedDictionary, module: str, archive_name: str
+) -> None:
+    """
+    Restore a module's contents from a tar.gz archive.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :param module: The module or submodule path (e.g., "mod-1/pkg-1").
+    :type module: str
+    :param archive_name: The name of the archive file.
+    :type archive_name: str
+    """
+
+    # Split the module path to get the top-level module
+    module_parts = module.split("/")
+    top_level_module = module_parts[0]
+
+    # Construct the path for the archive file
+    archive_path = (
+        build_path(
+            repository[["paths", "repository"]],
+            top_level_module,
+            I18N_TOOLS_LOCALE,
+            I18N_TOOLS_CONFIG,
+            I18N_TOOLS_BACKUP,
+        )
+        + f"/{archive_name}.tar.gz"
+    )
+
+    # Check if the archive file exists
+    if _exist_path(archive_path):
+        # Open the archive file in read mode with gzip compression
+        with tarfile.open(archive_path, "r:gz") as tar:
+            # Extract all members that are safe to extract
+            tar.extractall(
+                path=repository[["paths", "repository"]],
+                members=_non_traversal_path(
+                    repository[["paths", "repository"]],
+                    [top_level_module],
+                    tar.getmembers(),
+                ),
+            )
+    else:
+        # Raise an error if the archive file does not exist
+        raise FileNotFoundError(f"Archive file '{archive_path}' not found.")
+
+
+def build_repository(repository: StrictNestedDictionary) -> None:
+    """
+    This function builds the repository from the modulee and populates files in the repository directory respectively
+    to domains and language registered in the repository. It checks the existence of already existing files and only creates
+    the necessary files and directories.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :return: Nothing
+    :type: None
+    """
+    # Get the list of modules from the repository
+    modules = repository[["paths", "modules"]]
+
+    # Get the list of languages from the repository
+    languages = get_all_languages(repository[["languages", "hierarchy"]])
+
+    # Iterate through each module
+    for module in modules:
+        # Get the list of domains for this module
+        domains = repository[["domains", module]]
+
+        module_directory = (
+            repository[["paths", "repository"]] + "/" + module + "/" + I18N_TOOLS_LOCALE
+        )
+        module_template_directory = module_directory + "/" + I18N_TOOLS_TEMPLATE
+
+        if not _exist_path(module_template_directory):
+            create_directory(module_template_directory)
+
+        # Iterate through each domain
+        for domain in domains:
+            try:
+                # Create a template for this module and domain
+                create_template(repository, module, domain)
+            except FileExistsError:
+                # Skip if the template already exists
+                pass
+
+            # Iterate through each language
+            for language in languages:
+
+                language_directory = (
+                    module_directory + "/" + language + "/" + I18N_TOOLS_MESSAGES
+                )
+
+                if not _file_exists(language_directory):
+                    create_directory(language_directory)
+
+                try:
+                    # Create a catalog for this module, language, and domain
+                    create_catalog(repository, module, language, domain)
+                except FileExistsError:
+                    # Skip if the catalog already exists
+                    pass
+
+                try:
+                    # Create a dictionary for this module, language, and domain
+                    create_dictionary(repository, module, language, domain)
+                except FileExistsError:
+                    # Skip if the dictionary already exists
+                    pass
+
+
+def verify_repository(repository: StrictNestedDictionary) -> bool:
+    """
+    Verifies that the translation repository is properly constructed.
+    Checks the existence of required directories and files for each module, domain, and language.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :return: True if the repository is properly constructed, False otherwise.
+    :rtype: bool
+    """
+    try:
+        # Get the list of modules from the repository
+        modules = repository[["paths", "modules"]]
+
+        # Validate modules
+        if not _check_module(repository, modules):
+            return False
+
+        # Get the list of languages from the repository
+        languages = get_all_languages(repository[["languages", "hierarchy"]])
+
+        if not languages:
+            return False
+
+        # Check each module
+        for module in modules:
+            # Validate domains for this module
+            domains = repository[["domains", module]]
+            if not _check_domains(repository, module, domains):
+                return False
+
+            # Check module directory structure
+            module_directory = build_path(
+                repository[["paths", "repository"]], module, I18N_TOOLS_LOCALE
+            )
+            if not _exist_path(module_directory):
+                return False
+
+            # Check template directory
+            module_template_directory = build_path(
+                module_directory, I18N_TOOLS_TEMPLATE
+            )
+            if not _exist_path(module_template_directory):
+                return False
+
+            # Check each domain
+            for domain in domains:
+                # Check template file
+                template_path = build_path(module_template_directory, f"{domain}.pot")
+                if not _exist_path(template_path):
+                    return False
+
+                # Check each language
+                for language in languages:
+                    # Check language directory
+                    language_directory = build_path(
+                        module_directory, language, I18N_TOOLS_MESSAGES
+                    )
+                    if not _exist_path(language_directory):
+                        return False
+
+                    # Check catalog file
+                    catalog_path = build_path(language_directory, f"{domain}.po")
+                    if not _exist_path(catalog_path):
+                        return False
+
+                    # Check dictionary file (default json for backward compatibility)
+                    dictionary_path = _build_dictionary_path(
+                        language_directory, domain, None
+                    )
+                    if not _exist_path(dictionary_path):
+                        return False
+
+        # All checks passed
+        return True
+
+    except Exception:
+        return False
+
+
+def aggregate_dictionaries(
+    repository: StrictNestedDictionary, module: str, domain: str
+) -> None:
+    """
+    This function aggregates all dictionaries for a given module and domain into a single JSON file.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :param module: module where translation should be located.
+    :type module: str
+    :param domain: domain of translation.
+    :type domain: str
+    :return: Nothing
+    :rtype: None
+    :raises Exception: If any error occurs during the aggregation.
+    """
+
+    languages = get_all_languages(repository[["languages", "hierarchy"]])
+    domain_dictionary = {"metadata": repository["details"].to_dict()}
+
+    for language in languages:
+        try:
+            domain_dictionary[language] = fetch_dictionary(
+                repository, module, language, domain
+            )
+        except Exception as e:
+            raise e
+
+    module_directory = build_path(
+        repository[["paths", "repository"]], module, I18N_TOOLS_LOCALE
+    )
+    _save_json(module_directory + f"/{domain}_aggregated.json", domain_dictionary)
+    _create_gzip(module_directory + f"/{domain}_aggregated.json")
+
+
+def add_translation_set(
+    repository: StrictNestedDictionary, module: str, domain: str, translations: Dict
+):
+    """
+    Adds a translation set to the translation repository using JSON and PO files.
+
+    This function verifies the repository structure, updates the translation files
+    for each module, domain, and language, and ensures that the translations conform
+    to the languages defined in the repository.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :param module: Module where should be located domain of translations.
+    :type module: str
+    :param domain: The domain of the translation set.
+    :type domain: str
+    :param translations: Dictionary containing the translations to be added.
+    :raises ValueError: If the repository path is not absolute or if a language is not supported.
+    :raises FileNotFoundError: If any module path does not exist.
+    """
+    # Verifying components
+    _verify_paths_and_modules(repository)
+    _verify_available_languages(repository, list(translations.keys()))
+    _verify_target_domain(repository, module, domain)
+
+    for lang, translation_data in translations.items():
+
+        json_file_path, po_file_path, pot_file_path = build_translation_lang_files(
+            repository, module, domain, lang
+        )
+
+        # Load existing translations
+        existing_translations = (
+            fetch_dictionary(repository, module, lang, domain)
+            if _file_exists(json_file_path)
+            else {}
+        )
+        existing_translations = _update_json_translations(
+            existing_translations, translation_data
+        )
+        update_dictionary(repository, module, lang, domain, existing_translations)
+
+        # BLOCKED (v0.3.x) — update_catalog() incompatible with the i18n-tools format.
+        # The native .i18t matrix (messages/plurals/alternatives) does not match
+        # the msgid/msgstr structure expected by Babel. See backlog C-09.
+
+
+def update_translation_set(
+    repository: StrictNestedDictionary, module: str, domain: str, translations: Dict
+):
+    """
+    Updates existing translations in the translation repository using JSON and PO files.
+
+    This function verifies the repository structure, updates the translation files
+    for each module, domain, and language, and ensures that the translations conform
+    to the languages defined in the repository.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :param module: Module where the translation domain should be located.
+    :type module: str
+    :param domain: The domain of the translation set.
+    :type domain: str
+    :param translations: Dictionary containing the translations to be updated.
+    :raises ValueError: If the repository path is not absolute or if a language is not supported.
+    :raises FileNotFoundError: If any module path does not exist.
+    :raises KeyError: If a msgid to be updated does not exist in the current translations.
+    """
+    # Verify components
+    _verify_paths_and_modules(repository)
+    _verify_available_languages(repository, list(translations.keys()))
+    _verify_target_domain(repository, module, domain)
+
+    for lang, translation_data in translations.items():
+
+        json_file_path, po_file_path, pot_file_path = build_translation_lang_files(
+            repository, module, domain, lang
+        )
+        # Load existing translations
+        existing_translations = (
+            fetch_dictionary(repository, module, lang, domain)
+            if _file_exists(json_file_path)
+            else {}
+        )
+
+        # Update existing translations
+        for msgid, new_translations in translation_data.items():
+            if msgid not in existing_translations:
+                raise KeyError(
+                    f"msgid '{msgid}' does not exist in the current translations for language '{lang}'."
+                )
+            # Replace or extend existing translations
+            existing_translations[msgid] = new_translations
+
+        update_dictionary(repository, module, lang, domain, existing_translations)
+        # update_catalog(repository, module, lang, domain, existing_translations)
+
+
+def remove_translation_set(
+    repository: StrictNestedDictionary, module: str, domain: str, translations: Dict
+):
+    """
+    Removes specified translations from the translation repository using JSON and PO files.
+
+    This function verifies the repository structure, removes the specified translations
+    from the translation files for each module, domain, and language, and ensures that
+    the translations conform to the languages defined in the repository.
+
+    :param repository: The data structure which represents the repository information.
+    :type repository: StrictNestedDictionary
+    :param module: Module where the translation domain should be located.
+    :type module: str
+    :param domain: The domain of the translation set.
+    :type domain: str
+    :param translations: Dictionary containing the translations to be removed.
+    :raises ValueError: If the repository path is not absolute or if a language is not supported.
+    :raises FileNotFoundError: If any module path does not exist.
+    """
+    # Verify components
+    _verify_paths_and_modules(repository)
+    _verify_available_languages(repository, list(translations.keys()))
+    _verify_target_domain(repository, module, domain)
+
+    for lang, msgids in translations.items():
+
+        json_file_path, po_file_path, pot_file_path = build_translation_lang_files(
+            repository, module, domain, lang
+        )
+
+        # Load existing translations
+        existing_translations = (
+            fetch_dictionary(repository, module, lang, domain)
+            if _file_exists(json_file_path)
+            else {}
+        )
+
+        # Remove specified translations
+        for msgid, options in msgids.items():
+            if msgid in existing_translations:
+                del existing_translations[msgid]
+
+        dump_dictionary(repository, module, lang, domain, existing_translations)
+        # BLOCKED (v0.3.x) — update_catalog() incompatible with the i18n-tools format.
+        # The native .i18t matrix (messages/plurals/alternatives) does not match
+        # the msgid/msgstr structure expected by Babel. See backlog C-09.

--- a/src/i18n_tools/models/author.py
+++ b/src/i18n_tools/models/author.py
@@ -1,0 +1,159 @@
+"""
+Author and Authors — model objects for a translation author's identity
+and the collection of authors within a single Repository.
+
+`Repository` keeps its public `add_author`/`remove_author`/`update_author`/
+`clean_authors` methods (no breaking change for existing callers); their
+implementation delegates to `Authors`, which operates directly on the
+existing `repository["authors"]` StrictNestedDictionary section — there is
+no parallel storage to keep in sync.
+
+`Authors` is intentionally stateless: email lookups scan
+`repository["authors"]` rather than maintaining a separate index. Each
+Repository (e.g. Config's `package` and `application`) has its own,
+independent author set; cross-repository email deduplication, when
+needed, is the caller's responsibility (see Config.add_author), not
+something `Authors` enforces on its own.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+from uuid import UUID
+
+from ndict_tools import StrictNestedDictionary
+from ndict_tools.exception import StackedValueError
+
+if TYPE_CHECKING:
+    from .repository import Repository
+
+_DEFAULT_SETUP = {"indent": 2}
+
+
+class Author(StrictNestedDictionary):
+    """
+    Represents a single author: identity and link to translation languages.
+
+    Subclasses StrictNestedDictionary, exactly like Repository, so that
+    nested-key access, serialization (to_dict, inherited) and storage
+    inside a Repository's `authors` section behave consistently with the
+    rest of the model layer.
+    """
+
+    def __init__(
+        self,
+        first_name: str,
+        last_name: str,
+        email: str,
+        url: str,
+        languages: List[str],
+    ) -> None:
+        if not isinstance(languages, list):
+            raise TypeError("author['languages'] must be a list of strings")
+        super().__init__(default_setup=_DEFAULT_SETUP)
+        self["first_name"] = first_name
+        self["last_name"] = last_name
+        self["email"] = email
+        self["url"] = url
+        self["languages"] = languages
+
+    @classmethod
+    def from_payload(cls, data: dict) -> "Author":
+        """Validate and build an Author from a plain mapping.
+
+        Preserves the exact validation contract previously enforced by
+        Repository's private ``_validate_author_payload`` (same exception
+        types and messages).
+        """
+        if not isinstance(data, dict):
+            raise TypeError("author must be a dictionary")
+        required = {"first_name", "last_name", "email", "url", "languages"}
+        missing = required - set(data.keys())
+        if missing:
+            raise KeyError(f"author is missing required keys: {sorted(missing)}")
+        return cls(
+            first_name=data["first_name"],
+            last_name=data["last_name"],
+            email=data["email"],
+            url=data["url"],
+            languages=data["languages"],
+        )
+
+    @classmethod
+    def from_dict(cls, dictionary: dict, **class_options) -> "Author":
+        """
+        Override of _StackedDict.from_dict() — the recursive-construction
+        hook documented in ndict-tools' Extending guide. Author's __init__
+        has a domain-specific signature incompatible with the generic
+        cls(**class_options) reconstruction the base implementation
+        performs, so this redirects to from_payload() instead. Closes a
+        latent trap: without this override, Author would crash if ever
+        reconstructed through that generic path (e.g. as a default_factory
+        for a nested structure), exactly as it did before this fix.
+        """
+        return cls.from_payload(dictionary)
+
+
+def _validate_uuid4_string(value: str, name: str = "author_id") -> None:
+    """Validate that a value is a UUID4 string; raise consistent errors."""
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    try:
+        parsed = UUID(value)
+    except ValueError:
+        raise ValueError(f"{name} must be a valid UUID4 string")
+    if parsed.version != 4:
+        raise ValueError(f"{name} must be a valid UUID4 string")
+
+
+class Authors:
+    """Manager for the `authors` section of a single Repository."""
+
+    @staticmethod
+    def add(repository: "Repository", author_id: str, author: Author) -> None:
+        _validate_uuid4_string(author_id)
+        if author_id in repository["authors"].keys():
+            raise ValueError(f"Author '{author_id}' already exists")
+        repository[["authors", author_id]] = author
+
+    @staticmethod
+    def remove(repository: "Repository", author_id: str) -> None:
+        _validate_uuid4_string(author_id)
+        if author_id not in repository["authors"].keys():
+            raise ValueError(f"Author '{author_id}' does not exist")
+        del repository["authors"][author_id]
+
+    @staticmethod
+    def update(repository: "Repository", author_id: str, updates: dict) -> None:
+        _validate_uuid4_string(author_id)
+        if not isinstance(updates, dict):
+            raise TypeError("updates must be a dictionary")
+        if author_id not in repository["authors"].keys():
+            raise ValueError(f"Author '{author_id}' does not exist")
+        current = repository[["authors", author_id]]
+        for key, value in updates.items():
+            if key not in current.keys():
+                raise KeyError(f"Key '{key}' is not a valid field for author")
+            if type(value) != type(current[key]):
+                raise TypeError(
+                    f"Type mismatch for '{key}': expected {type(current[key])}, got {type(value)}"
+                )
+            current[key] = value
+
+    @staticmethod
+    def get_id_by_email(repository: "Repository", email: str) -> Optional[str]:
+        """Find the author UUID owning the given email.
+
+        Uses ndict-tools' own value-search primitive (ancestors(), a DFS
+        over the tree) instead of a manual scan: the email value's
+        ancestry path, excluding its own key, is exactly the author_id.
+        """
+        try:
+            ancestry = repository["authors"].ancestors(email)
+        except StackedValueError:
+            return None
+        return ancestry[-1] if ancestry else None
+
+    @staticmethod
+    def clean(repository: "Repository") -> None:
+        repository["authors"] = repository._new_section({})

--- a/src/i18n_tools/models/init.py
+++ b/src/i18n_tools/models/init.py
@@ -1,0 +1,4 @@
+from .author import Author, Authors
+from .corpus import Book, Corpus, Encyclopaedia, FallbackBook, Message
+from .repository import Repository
+from .translator import Translator, Translators

--- a/src/i18n_tools/models/repository.py
+++ b/src/i18n_tools/models/repository.py
@@ -37,199 +37,13 @@ from uuid import UUID
 
 from ndict_tools import StrictNestedDictionary
 
-from ..api import validate_url_format
 from ..loaders.loader import file_exists, is_absolute_path, normalize_module_identifier
 from ..locale import normalize_languages_hierarchy
+from .author import Author, Authors
+from .translator import Translators
 
 # Shared default setup to avoid repetition
 _DEFAULT_SETUP = {"indent": 2}
-
-
-# --- Module-private helpers (factorized logic for authors/domains) ---
-
-
-def _validate_uuid4_string(value: str, name: str = "author_id") -> None:
-    """Validate that a value is a UUID4 string; raise consistent errors.
-
-    Keeps exact error messages used across Repository author helpers.
-    """
-    if not isinstance(value, str):
-        raise TypeError(f"{name} must be a string")
-    try:
-        parsed = UUID(value)
-    except ValueError:
-        raise ValueError(f"{name} must be a valid UUID4 string")
-    if parsed.version != 4:
-        raise ValueError(f"{name} must be a valid UUID4 string")
-
-
-def _ensure_author_exists(
-    repo: "Repository", author_id: str, should_exist: bool
-) -> None:
-    """Check presence of an author and raise ValueError with consistent message."""
-    exists = author_id in repo["authors"].keys()
-    if should_exist and not exists:
-        raise ValueError(f"Author '{author_id}' does not exist")
-    if not should_exist and exists:
-        raise ValueError(f"Author '{author_id}' already exists")
-
-
-def _validate_author_payload(author: dict) -> None:
-    """Validate the structure of an author mapping."""
-    if not isinstance(author, dict):
-        raise TypeError("author must be a dictionary")
-    required = {"first_name", "last_name", "email", "url", "languages"}
-    missing = required - set(author.keys())
-    if missing:
-        # keep list-like formatting as in original code (sorted list emitted)
-        raise KeyError(f"author is missing required keys: {sorted(missing)}")
-    if not isinstance(author.get("languages"), list):
-        raise TypeError("author['languages'] must be a list of strings")
-
-
-def _validate_translator_payload(translator: dict) -> None:
-    """Validate the structure of a translator mapping.
-
-    Expected nested structure and minimal type checks:
-      - details: { name: str, status: str, url: str }
-      - pricing: { cost_per_translation: float|int|None, payment_plan: str|None }
-      - technical:
-          api: { key: str, key_expiration: str|None|"", request_limit: int }
-          performance: { max_text_size: int, priority: int, success_rate: float|int }
-
-    Additionally validates details.url via validate_api_url and checks
-    key_expiration format YYYY-MM-DD when provided (non-empty).
-    """
-    if not isinstance(translator, dict):
-        raise TypeError("Translator must be a dictionary")
-
-    # Top-level required keys
-    top_required = {"details", "pricing", "technical"}
-    missing_top = top_required - set(translator.keys())
-    if missing_top:
-        raise KeyError(f"Translator is missing required keys: {sorted(missing_top)}")
-
-    # details validation
-    details = translator.get("details")
-    if not isinstance(details, dict):
-        raise TypeError("Translator['details'] must be a dictionary")
-    det_required = {"name", "status", "url"}
-    missing_det = det_required - set(details.keys())
-    if missing_det:
-        raise KeyError(
-            f"Translator['details'] is missing required keys: {sorted(missing_det)}"
-        )
-    if not isinstance(details.get("name"), str):
-        raise TypeError("Translator[['details', 'name']] must be a string")
-    if not isinstance(details.get("status"), str):
-        raise TypeError("Translator[['details', 'status']] must be a string")
-    if not isinstance(details.get("url"), str):
-        raise TypeError("Translator[['details', 'url']] must be a string")
-    # Structural validation only — no network call (KI-01, DD-NN).
-    # The real availability check (api.validate_api_url) is invoked
-    # explicitly elsewhere (Config/CLI), never from this synchronous path.
-    result = validate_url_format(details.get("url"))
-    if result.get("error"):
-        raise ValueError(result["error"])
-
-    # pricing validation
-    pricing = translator.get("pricing")
-    if not isinstance(pricing, dict):
-        raise TypeError("Translator['pricing'] must be a dictionary")
-    pr_required = {"cost_per_translation", "payment_plan"}
-    missing_pr = pr_required - set(pricing.keys())
-    if missing_pr:
-        raise KeyError(
-            f"Translator['pricing'] is missing required keys: {sorted(missing_pr)}"
-        )
-    cpt = pricing.get("cost_per_translation")
-    if cpt is not None and not isinstance(cpt, (int, float)):
-        raise TypeError(
-            "Translator[['pricing', 'cost_per_translation']] must be a number or None"
-        )
-    plan = pricing.get("payment_plan")
-    if plan is not None and not isinstance(plan, str):
-        raise TypeError(
-            "Translator[['pricing', 'payment_plan']] must be a string or None"
-        )
-
-    # technical validation
-    technical = translator.get("technical")
-    if not isinstance(technical, dict):
-        raise TypeError("Translator['technical'] must be a dictionary")
-    tech_required = {"api", "performance"}
-    missing_tech = tech_required - set(technical.keys())
-    if missing_tech:
-        raise KeyError(
-            f"Translator['technical'] is missing required keys: {sorted(missing_tech)}"
-        )
-
-    # technical.api
-    api = technical.get("api")
-    if not isinstance(api, dict):
-        raise TypeError("Translator[['technical', 'api']] must be a dictionary")
-    api_required = {"key", "key_expiration", "request_limit"}
-    missing_api = api_required - set(api.keys())
-    if missing_api:
-        raise KeyError(
-            f"Translator[['technical', 'api']] is missing required keys: {sorted(missing_api)}"
-        )
-    if not isinstance(api.get("key"), str):
-        raise TypeError("Translator[['technical', 'api', 'key']] must be a string")
-    key_exp = api.get("key_expiration")
-    if key_exp is not None and not isinstance(key_exp, str):
-        raise TypeError(
-            "Translator[['technical', 'api', 'key_expiration']] must be a string or None"
-        )
-    if isinstance(key_exp, str) and key_exp.strip():
-        try:
-            datetime.strptime(key_exp, "%Y-%m-%d")
-        except ValueError:
-            raise ValueError(
-                "Translator[['technical', 'api', 'key_expiration']] must be in 'YYYY-MM-DD' format"
-            )
-    if not isinstance(api.get("request_limit"), int):
-        raise TypeError(
-            "Translator[['technical', 'api', 'request_limit']] must be an integer"
-        )
-
-    # technical.performance
-    perf = technical.get("performance")
-    if not isinstance(perf, dict):
-        raise TypeError("Translator[['technical', 'performance']] must be a dictionary")
-    perf_required = {"max_text_size", "priority", "success_rate"}
-    missing_perf = perf_required - set(perf.keys())
-    if missing_perf:
-        raise KeyError(
-            f"Translator[['technical', 'performance']] is missing required keys: {sorted(missing_perf)}"
-        )
-    if not isinstance(perf.get("max_text_size"), int):
-        raise TypeError(
-            "Translator[['technical', 'performance', 'max_text_size']] must be an integer"
-        )
-    if not isinstance(perf.get("priority"), int):
-        raise TypeError(
-            "Translator[['technical', 'performance', 'priority']] must be an integer"
-        )
-    sr = perf.get("success_rate")
-    if not isinstance(sr, (int, float)):
-        raise TypeError(
-            "Translator[['technical', 'performance', 'success_rate']] must be a number"
-        )
-
-
-def _apply_typed_updates(current: StrictNestedDictionary, updates: dict) -> None:
-    """Apply updates ensuring keys exist and types match current values."""
-    if not isinstance(updates, dict):
-        raise TypeError("updates must be a dictionary")
-    for k, v in updates.items():
-        if k not in current.keys():
-            raise KeyError(f"Key '{k}' is not a valid field for author")
-        if type(v) != type(current[k]):
-            raise TypeError(
-                f"Type mismatch for '{k}': expected {type(current[k])}, got {type(v)}"
-            )
-        current[k] = v
 
 
 # --- Domains helpers ---
@@ -727,36 +541,25 @@ class Repository(StrictNestedDictionary):
 
         This method mirrors the structure expected by Config.add_author outputs,
         but here you explicitly provide the identifier and the author mapping.
+        Delegates to Authors.add() (models/author.py, DD-NN).
         """
-        _validate_uuid4_string(author_id, "author_id")
-        _validate_author_payload(author)
-        _ensure_author_exists(self, author_id, should_exist=False)
-        # Ensure authors sub-dicts are StrictNestedDictionary for consistency
-        self[["authors", author_id]] = StrictNestedDictionary(
-            author, default_setup=_DEFAULT_SETUP
-        )
+        Authors.add(self, author_id, Author.from_dict(author))
 
     def remove_author(self, author_id: str) -> None:
-        """Remove an author by its identifier."""
-
-        _validate_uuid4_string(author_id, "author_id")
-        _ensure_author_exists(self, author_id, should_exist=True)
-        del self["authors"][author_id]
+        """Remove an author by its identifier. Delegates to Authors.remove()."""
+        Authors.remove(self, author_id)
 
     def update_author(self, author_id: str, updates: dict) -> None:
         """Update fields of an existing author with type checking.
 
-        Only existing keys can be updated and their types must match the current values.
+        Only existing keys can be updated and their types must match the
+        current values. Delegates to Authors.update().
         """
-
-        _validate_uuid4_string(author_id, "author_id")
-        _ensure_author_exists(self, author_id, should_exist=True)
-        current = self[["authors", author_id]]
-        _apply_typed_updates(current, updates)
+        Authors.update(self, author_id, updates)
 
     def clean_authors(self) -> None:
-        """Remove all authors."""
-        self["authors"] = self._new_section({})
+        """Remove all authors. Delegates to Authors.clean()."""
+        Authors.clean(self)
 
     # --- translators helpers ---
 
@@ -778,82 +581,28 @@ class Repository(StrictNestedDictionary):
         """Add a new translator entry.
 
         Mirrors add_author: caller provides the unique name and a dictionary
-        holding the translator data. Minimal validation is performed here; the
-        structure can later be updated with update_translator which enforces
-        type safety recursively.
+        holding the translator data. Delegates to Translators.add()
+        (models/translator.py, DD-NN).
         """
-        if not isinstance(name, str):
-            raise TypeError("Translator name must be a string")
-        if not isinstance(translator, dict):
-            raise TypeError("Translator content must be a dictionary")
-
-        # Validate translator payload structure (strict nested schema)
-        _validate_translator_payload(translator)
-
-        # Ensure translators section exists as a StrictNestedDictionary
-        if not isinstance(self["translators"], StrictNestedDictionary):
-            self["translators"] = self._new_section({})
-
-        # Check duplicates (align with authors helpers semantics)
-        if name in self["translators"].keys():
-            raise ValueError(f"Translator '{name}' already exists")
-
-        self[["translators", name]] = StrictNestedDictionary(
-            translator, default_setup=_DEFAULT_SETUP
-        )
+        Translators.add(self, name, translator)
 
     def update_translator(self, name: str, updates: dict) -> None:
         """
         Update an existing translator's details with structural validation.
 
         The provided updates must match the existing nested structure (keys and
-        value types). Unknown keys raise KeyError and type mismatches raise TypeError.
+        value types). Unknown keys raise KeyError and type mismatches raise
+        TypeError. Delegates to Translators.update().
         """
-        if not isinstance(name, str):
-            raise TypeError("name must be a string")
-        if not isinstance(updates, dict):
-            raise TypeError("updates must be a dictionary")
-
-        translators = self["translators"]
-        if name not in translators.keys():
-            raise ValueError(f"Translator '{name}' does not exist")
-
-        existing_translator = translators[name]
-
-        def validate_and_apply(target: dict, patch: dict, path: str = "") -> None:
-            for key, value in patch.items():
-                full_path = f"{path}.{key}" if path else key
-                if key not in target:
-                    raise KeyError(
-                        f"Key '{full_path}' is not a valid field for translator"
-                    )
-                if isinstance(target[key], dict):
-                    if not isinstance(value, dict):
-                        raise TypeError(
-                            f"Type mismatch for '{full_path}': expected dict, got {type(value)}"
-                        )
-                    validate_and_apply(target[key], value, full_path)
-                else:
-                    if type(value) != type(target[key]):
-                        raise TypeError(
-                            f"Type mismatch for '{full_path}': expected {type(target[key])}, got {type(value)}"
-                        )
-                    target[key] = value
-
-        validate_and_apply(existing_translator, updates)
+        Translators.update(self, name, updates)
 
     def remove_translator(self, name: str) -> None:
         """Remove a translator by its unique name.
 
-        Aligns with remove_author semantics: raises ValueError if the translator
-        does not exist.
+        Aligns with remove_author semantics: raises ValueError if the
+        translator does not exist. Delegates to Translators.remove().
         """
-        if not isinstance(name, str):
-            raise TypeError("name must be a string")
-        translators = self["translators"]
-        if name not in translators.keys():
-            raise ValueError(f"Translator '{name}' does not exist")
-        del translators[name]
+        Translators.remove(self, name)
 
     def clean_translators(self) -> None:
         """
@@ -862,7 +611,7 @@ class Repository(StrictNestedDictionary):
         :return: None
         :rtype: None
         """
-        self["translators"] = self._new_section({})
+        Translators.clean(self)
 
     def add_value(self, path: list[str], value: Any) -> None:
         """

--- a/src/i18n_tools/models/repository.py
+++ b/src/i18n_tools/models/repository.py
@@ -37,8 +37,8 @@ from uuid import UUID
 
 from ndict_tools import StrictNestedDictionary
 
-from ..api import validate_api_url
-from ..loaders.handler import file_exists, is_absolute_path, normalize_module_identifier
+from ..api import validate_url_format
+from ..loaders.loader import file_exists, is_absolute_path, normalize_module_identifier
 from ..locale import normalize_languages_hierarchy
 
 # Shared default setup to avoid repetition
@@ -125,8 +125,10 @@ def _validate_translator_payload(translator: dict) -> None:
         raise TypeError("Translator[['details', 'status']] must be a string")
     if not isinstance(details.get("url"), str):
         raise TypeError("Translator[['details', 'url']] must be a string")
-    # validate URL via shared API helper
-    result = validate_api_url(details.get("url"))
+    # Structural validation only — no network call (KI-01, DD-NN).
+    # The real availability check (api.validate_api_url) is invoked
+    # explicitly elsewhere (Config/CLI), never from this synchronous path.
+    result = validate_url_format(details.get("url"))
     if result.get("error"):
         raise ValueError(result["error"])
 

--- a/src/i18n_tools/models/translator.py
+++ b/src/i18n_tools/models/translator.py
@@ -1,0 +1,274 @@
+"""
+Translator and Translators — model objects for an automatic translation
+service entry (e.g. a paid API like Google Translate, DeepL) and the
+collection of such services within a single Repository.
+
+`Repository` keeps its public `add_translator`/`update_translator`/
+`remove_translator`/`clean_translators` methods (no breaking change for
+existing callers); their implementation delegates to `Translators`, which
+operates directly on the existing `repository["translators"]`
+StrictNestedDictionary section.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from ndict_tools import StrictNestedDictionary
+
+from ..api import validate_url_format
+
+if TYPE_CHECKING:
+    from .repository import Repository
+
+_DEFAULT_SETUP = {"indent": 2}
+
+
+class Translator(StrictNestedDictionary):
+    """
+    Represents a single automatic translation service entry.
+
+    Subclasses StrictNestedDictionary, exactly like Repository and Author,
+    so that nested-key access and serialization behave consistently with
+    the rest of the model layer.
+    """
+
+    def __init__(self, details: dict, pricing: dict, technical: dict) -> None:
+        payload = {"details": details, "pricing": pricing, "technical": technical}
+        self.validate_payload(payload)
+        super().__init__(default_setup=_DEFAULT_SETUP)
+        self["details"] = StrictNestedDictionary(details, default_setup=_DEFAULT_SETUP)
+        self["pricing"] = StrictNestedDictionary(pricing, default_setup=_DEFAULT_SETUP)
+        self["technical"] = StrictNestedDictionary(
+            technical, default_setup=_DEFAULT_SETUP
+        )
+
+    @classmethod
+    def from_payload(cls, data: dict) -> "Translator":
+        """Validate and build a Translator from a plain mapping."""
+        cls.validate_payload(data)
+        return cls(
+            details=data["details"],
+            pricing=data["pricing"],
+            technical=data["technical"],
+        )
+
+    @classmethod
+    def from_dict(cls, dictionary: dict, **class_options) -> "Translator":
+        """
+        Override of _StackedDict.from_dict() — see Author.from_dict() for
+        the rationale (ndict-tools' Extending guide). Redirects to
+        from_payload() instead of the incompatible generic
+        cls(**class_options) reconstruction.
+        """
+        return cls.from_payload(dictionary)
+
+    @staticmethod
+    def validate_payload(translator: dict) -> None:
+        """Validate the structure of a translator mapping.
+
+        Expected nested structure and minimal type checks:
+          - details: { name: str, status: str, url: str }
+          - pricing: { cost_per_translation: float|int|None, payment_plan: str|None }
+          - technical:
+              api: { key: str, key_expiration: str|None|"", request_limit: int }
+              performance: { max_text_size: int, priority: int, success_rate: float|int }
+
+        Additionally validates details.url via validate_url_format (syntax
+        only — no network call, KI-01/DD-NN) and checks key_expiration
+        format YYYY-MM-DD when provided (non-empty).
+
+        Preserves the exact validation contract previously enforced by
+        Repository's private ``_validate_translator_payload`` (same
+        exception types and messages).
+        """
+        if not isinstance(translator, dict):
+            raise TypeError("Translator must be a dictionary")
+
+        # Top-level required keys
+        top_required = {"details", "pricing", "technical"}
+        missing_top = top_required - set(translator.keys())
+        if missing_top:
+            raise KeyError(
+                f"Translator is missing required keys: {sorted(missing_top)}"
+            )
+
+        # details validation
+        details = translator.get("details")
+        if not isinstance(details, dict):
+            raise TypeError("Translator['details'] must be a dictionary")
+        det_required = {"name", "status", "url"}
+        missing_det = det_required - set(details.keys())
+        if missing_det:
+            raise KeyError(
+                f"Translator['details'] is missing required keys: {sorted(missing_det)}"
+            )
+        if not isinstance(details.get("name"), str):
+            raise TypeError("Translator[['details', 'name']] must be a string")
+        if not isinstance(details.get("status"), str):
+            raise TypeError("Translator[['details', 'status']] must be a string")
+        if not isinstance(details.get("url"), str):
+            raise TypeError("Translator[['details', 'url']] must be a string")
+        # Structural validation only — no network call (KI-01, DD-NN).
+        # The real availability check (api.validate_api_url) is invoked
+        # explicitly elsewhere (Config/CLI), never from this synchronous path.
+        result = validate_url_format(details.get("url"))
+        if result.get("error"):
+            raise ValueError(result["error"])
+
+        # pricing validation
+        pricing = translator.get("pricing")
+        if not isinstance(pricing, dict):
+            raise TypeError("Translator['pricing'] must be a dictionary")
+        pr_required = {"cost_per_translation", "payment_plan"}
+        missing_pr = pr_required - set(pricing.keys())
+        if missing_pr:
+            raise KeyError(
+                f"Translator['pricing'] is missing required keys: {sorted(missing_pr)}"
+            )
+        cpt = pricing.get("cost_per_translation")
+        if cpt is not None and not isinstance(cpt, (int, float)):
+            raise TypeError(
+                "Translator[['pricing', 'cost_per_translation']] must be a number or None"
+            )
+        plan = pricing.get("payment_plan")
+        if plan is not None and not isinstance(plan, str):
+            raise TypeError(
+                "Translator[['pricing', 'payment_plan']] must be a string or None"
+            )
+
+        # technical validation
+        technical = translator.get("technical")
+        if not isinstance(technical, dict):
+            raise TypeError("Translator['technical'] must be a dictionary")
+        tech_required = {"api", "performance"}
+        missing_tech = tech_required - set(technical.keys())
+        if missing_tech:
+            raise KeyError(
+                f"Translator['technical'] is missing required keys: {sorted(missing_tech)}"
+            )
+
+        # technical.api
+        api = technical.get("api")
+        if not isinstance(api, dict):
+            raise TypeError("Translator[['technical', 'api']] must be a dictionary")
+        api_required = {"key", "key_expiration", "request_limit"}
+        missing_api = api_required - set(api.keys())
+        if missing_api:
+            raise KeyError(
+                f"Translator[['technical', 'api']] is missing required keys: {sorted(missing_api)}"
+            )
+        if not isinstance(api.get("key"), str):
+            raise TypeError("Translator[['technical', 'api', 'key']] must be a string")
+        key_exp = api.get("key_expiration")
+        if key_exp is not None and not isinstance(key_exp, str):
+            raise TypeError(
+                "Translator[['technical', 'api', 'key_expiration']] must be a string or None"
+            )
+        if isinstance(key_exp, str) and key_exp.strip():
+            try:
+                datetime.strptime(key_exp, "%Y-%m-%d")
+            except ValueError:
+                raise ValueError(
+                    "Translator[['technical', 'api', 'key_expiration']] must be in 'YYYY-MM-DD' format"
+                )
+        if not isinstance(api.get("request_limit"), int):
+            raise TypeError(
+                "Translator[['technical', 'api', 'request_limit']] must be an integer"
+            )
+
+        # technical.performance
+        perf = technical.get("performance")
+        if not isinstance(perf, dict):
+            raise TypeError(
+                "Translator[['technical', 'performance']] must be a dictionary"
+            )
+        perf_required = {"max_text_size", "priority", "success_rate"}
+        missing_perf = perf_required - set(perf.keys())
+        if missing_perf:
+            raise KeyError(
+                f"Translator[['technical', 'performance']] is missing required keys: {sorted(missing_perf)}"
+            )
+        if not isinstance(perf.get("max_text_size"), int):
+            raise TypeError(
+                "Translator[['technical', 'performance', 'max_text_size']] must be an integer"
+            )
+        if not isinstance(perf.get("priority"), int):
+            raise TypeError(
+                "Translator[['technical', 'performance', 'priority']] must be an integer"
+            )
+        sr = perf.get("success_rate")
+        if not isinstance(sr, (int, float)):
+            raise TypeError(
+                "Translator[['technical', 'performance', 'success_rate']] must be a number"
+            )
+
+
+class Translators:
+    """Manager for the `translators` section of a single Repository."""
+
+    @staticmethod
+    def add(repository: "Repository", name: str, translator: dict) -> None:
+        if not isinstance(name, str):
+            raise TypeError("Translator name must be a string")
+        if not isinstance(translator, dict):
+            raise TypeError("Translator content must be a dictionary")
+
+        translator_obj = Translator.from_payload(translator)
+
+        if not isinstance(repository["translators"], StrictNestedDictionary):
+            repository["translators"] = repository._new_section({})
+
+        if name in repository["translators"].keys():
+            raise ValueError(f"Translator '{name}' already exists")
+
+        repository[["translators", name]] = translator_obj
+
+    @staticmethod
+    def update(repository: "Repository", name: str, updates: dict) -> None:
+        if not isinstance(name, str):
+            raise TypeError("name must be a string")
+        if not isinstance(updates, dict):
+            raise TypeError("updates must be a dictionary")
+
+        translators = repository["translators"]
+        if name not in translators.keys():
+            raise ValueError(f"Translator '{name}' does not exist")
+
+        existing_translator = translators[name]
+
+        def validate_and_apply(target: dict, patch: dict, path: str = "") -> None:
+            for key, value in patch.items():
+                full_path = f"{path}.{key}" if path else key
+                if key not in target:
+                    raise KeyError(
+                        f"Key '{full_path}' is not a valid field for translator"
+                    )
+                if isinstance(target[key], dict):
+                    if not isinstance(value, dict):
+                        raise TypeError(
+                            f"Type mismatch for '{full_path}': expected dict, got {type(value)}"
+                        )
+                    validate_and_apply(target[key], value, full_path)
+                else:
+                    if type(value) != type(target[key]):
+                        raise TypeError(
+                            f"Type mismatch for '{full_path}': expected {type(target[key])}, got {type(value)}"
+                        )
+                    target[key] = value
+
+        validate_and_apply(existing_translator, updates)
+
+    @staticmethod
+    def remove(repository: "Repository", name: str) -> None:
+        if not isinstance(name, str):
+            raise TypeError("name must be a string")
+        translators = repository["translators"]
+        if name not in translators.keys():
+            raise ValueError(f"Translator '{name}' does not exist")
+        del translators[name]
+
+    @staticmethod
+    def clean(repository: "Repository") -> None:
+        repository["translators"] = repository._new_section({})

--- a/tests/00_api/test_00_api.py
+++ b/tests/00_api/test_00_api.py
@@ -28,7 +28,7 @@ class TestValidateApiUrl:
                 {"is_alive": True, "status_code": 200, "error": None},
             ),
             (
-                "https://httpbin.org/get",
+                "https://httpbingo.org/get",
                 {"is_alive": True, "status_code": 200, "error": None},
             ),
             (
@@ -36,11 +36,11 @@ class TestValidateApiUrl:
                 {"is_alive": True, "status_code": 200, "error": None},
             ),
             (
-                "https://httpbin.org/status/204",
+                "https://httpbingo.org/status/204",
                 {"is_alive": True, "status_code": 204, "error": None},
             ),
             (
-                "https://httpbin.org/status/401",
+                "https://httpbingo.org/status/401",
                 {"is_alive": True, "status_code": 401, "error": None},
             ),
         ],
@@ -124,7 +124,7 @@ class TestValidateApiUrlTimeouts:
         "url,timeout,expected",
         [
             (
-                "https://httpbin.org/delay/10",
+                "https://httpbingo.org/delay/10",
                 5,
                 {
                     "is_alive": False,
@@ -133,7 +133,7 @@ class TestValidateApiUrlTimeouts:
                 },
             ),
             (
-                "https://httpbin.org/delay/15",
+                "https://httpbingo.org/delay/6",
                 5,
                 {
                     "is_alive": False,
@@ -142,7 +142,7 @@ class TestValidateApiUrlTimeouts:
                 },
             ),
             (
-                "https://httpbin.org/delay/25",
+                "https://httpbingo.org/delay/8",
                 5,
                 {
                     "is_alive": False,
@@ -158,7 +158,7 @@ class TestValidateApiUrlTimeouts:
         """
         Tests validate_api_url with URLs simulating timeouts.
 
-        Decorated @pytest.mark.network — runs on master only (real httpbin.org calls).
+        Decorated @pytest.mark.network — runs on master only (real httpbingo.org calls).
         On dev branches, patch_validate_api_url intercepts the call via the mock.
         Error message is always English (DD-35).
         """

--- a/tests/01_loader/test_02_loader.py
+++ b/tests/01_loader/test_02_loader.py
@@ -25,7 +25,7 @@ from i18n_tools.loaders.handler import (
     update_catalog,
     update_dictionary,
 )
-from i18n_tools.loaders.repository import (
+from i18n_tools.loaders.loader import (
     _update_json_translations,
     add_translation_set,
     aggregate_dictionaries,

--- a/tests/02_models/test_00_message.py
+++ b/tests/02_models/test_00_message.py
@@ -423,7 +423,6 @@ class TestMessageGetMetadata:
             ("en_message", ["count", "plurals"], [2, 2, 2]),
         ],
     )
-    @pytest.mark.skip(reason="ndict_tools equality has be rewieved")
     def test_message_get_metadata(self, fixture_name, path, expected, request) -> None:
         message = request.getfixturevalue(fixture_name)
         assert message.get_metadata(path) == expected
@@ -576,7 +575,6 @@ class TestMessageAdd:
             ),
         ],
     )
-    @pytest.mark.skip(reason="ndict_tools equality has be rewieved")
     def test_message_add_message(
         self, fixture_name, options, expected, request
     ) -> None:
@@ -1193,7 +1191,6 @@ class TestMessageAddSegment:
             ),
         ],
     )
-    @pytest.mark.skip(reason="ndict_tools equality has be rewieved")
     def test_message_add_options_plurals_segment(
         self, empty_message, options, alt_index, additional, expected
     ) -> None:
@@ -1642,7 +1639,6 @@ class TestMessageUpdate:
             ),
         ],
     )
-    @pytest.mark.skip(reason="ndict_tools equality has be rewieved")
     def test_message_update_message(self, options, expected) -> None:
         message = Message("1001", "A test for update message")
         message.update_message(**options)

--- a/tests/02_models/test_01_book.py
+++ b/tests/02_models/test_01_book.py
@@ -515,7 +515,6 @@ class TestBookMetadata:
             ("custom_meta", {"a": 1}, ["custom_meta"], {"a": 1}),
         ],
     )
-    @pytest.mark.skip(reason="ndict_tools equality has be rewieved")
     @pytest.mark.parametrize(
         "fixture_book", ["fr_fr_book"]
     )  # one is enough for API checks

--- a/tests/09_config/test_config.py
+++ b/tests/09_config/test_config.py
@@ -1043,7 +1043,7 @@ class TestConfigTranslators:
                 "application",
                 {
                     "name": "Translator3",
-                    "url": "https://doe.com",
+                    "url": "https://httpbingo.org/get",
                     "status": "private",
                     "api_key": "apikey456",
                     "supported_languages": ["fr", "en", "ga", "it"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def mock_validate_api_url(url: str, timeout: int = 5) -> dict:
             "status_code": 200,
             "error": None,
         },
-        "https://httpbin.org/get": {
+        "https://httpbingo.org/get": {
             "url": url,
             "is_alive": True,
             "status_code": 200,
@@ -195,37 +195,37 @@ def mock_validate_api_url(url: str, timeout: int = 5) -> dict:
             "status_code": 200,
             "error": None,
         },
-        "https://httpbin.org/status/204": {
+        "https://httpbingo.org/status/204": {
             "url": url,
             "is_alive": True,
             "status_code": 204,
             "error": None,
         },
-        "https://httpbin.org/status/401": {
+        "https://httpbingo.org/status/401": {
             "url": url,
             "is_alive": True,
             "status_code": 401,
             "error": None,
         },
-        "https://httpbin.org/status/403": {
+        "https://httpbingo.org/status/403": {
             "url": url,
             "is_alive": True,
             "status_code": 403,
             "error": None,
         },
-        "https://httpbin.org/status/405": {
+        "https://httpbingo.org/status/405": {
             "url": url,
             "is_alive": True,
             "status_code": 405,
             "error": None,
         },
-        "https://httpbin.org/status/429": {
+        "https://httpbingo.org/status/429": {
             "url": url,
             "is_alive": True,
             "status_code": 429,
             "error": None,
         },
-        "https://httpbin.org/status/500": {
+        "https://httpbingo.org/status/500": {
             "url": url,
             "is_alive": True,
             "status_code": 500,
@@ -250,26 +250,21 @@ def mock_validate_api_url(url: str, timeout: int = 5) -> dict:
             "status_code": 200,
             "error": None,
         },
-        "https://doe.com": {
-            "url": url,
-            "is_alive": True,
-            "status_code": 200,
-            "error": None,
-        },
-        # Simulating delays — DD-35: always English
-        "https://httpbin.org/delay/10": {
+        # "https://httpbingo.org/get" reused for the Translator3 case below
+        # (was "https://doe.com", drifted to a real 404 — see test_config.py).
+        "https://httpbingo.org/delay/10": {
             "url": url,
             "is_alive": False,
             "status_code": None,
             "error": "Connection timed out." if timeout < 10 else None,
         },
-        "https://httpbin.org/delay/15": {
+        "https://httpbingo.org/delay/6": {
             "url": url,
             "is_alive": False,
             "status_code": None,
             "error": "Connection timed out." if timeout < 15 else None,
         },
-        "https://httpbin.org/delay/25": {
+        "https://httpbingo.org/delay/8": {
             "url": url,
             "is_alive": False,
             "status_code": None,
@@ -390,9 +385,6 @@ def patch_validate_api_url(is_main_branch):
         with (
             mock.patch("i18n_tools.api.validate_api_url", mock_validate_api_url),
             mock.patch("i18n_tools.config.validate_api_url", mock_validate_api_url),
-            mock.patch(
-                "i18n_tools.models.repository.validate_api_url", mock_validate_api_url
-            ),
         ):
             yield
 


### PR DESCRIPTION
### Summary

This release seals the boundary between `/models/` and the rest of `/loaders/` (DD-06), removes the structural root cause of KI-01, and completes the `Config → Repository` migration that had been frozen since v0.2.x pending `ndict-tools` serialization support.

Closes the v0.5.x milestone: #69, #70, #17, #25.

### What changed

- **`api.py`** — `validate_url_format()` added (pure syntax check, no  network).
- **`loaders/loader.py`** — sole bridge between `/models/` and the rest of  `/loaders/`. Absorbed the 8 functions of the now-retired `loaders/repository.py`, plus 3 new pass-throughs (`file_exists`, `is_absolute_path`, normalize_module_identifier`).
- **`loaders/repository.py`** — **removed** (pre-DD-06 legacy, no production callers).
- **`models/repository.py`** — zero direct I/O. Routes exclusively through `loader.py`; `validate_api_url` replaced by `validate_url_format`. **Closes KI-01.**
- **`models/author.py`, `models/translator.py`** *(new)* — `Author`, `Authors`, `Translator`, `Translators`. Subclass `StrictNestedDictionary` like `Repository`. `Repository`'s public author/translator API is unchanged; construction/validation/storage now delegates to these objects.
- **`config.py`** — `_email_index` removed entirely; no parallel state. Cross-config (`package`/`application`) email lookup queries both `Repository` instances via `Authors.get_id_by_email()` (using `ndict-tools`' own `ancestors()` — DFS value search — not a manual scan). `add_author`/`add_translator`/`update_translator`/`remove_author` now delegate their storage mutation to `Repository`, while keeping their own pre-checks so the exceptions/messages a caller sees are unchanged (transparent delegation).
- **Tests** — `httpbin.org` → `httpbingo.org` (flaky external service); 5 long-standing `@pytest.mark.skip` equality tests unskipped (fixed in `ndict-tools` 1.2.0, confirmed empirically — no rewrite needed).
- **Version** — `0.4.0` → `0.5.0` (`pyproject.toml`, `__static__.py`).

### Test baseline

`master` before: 1069 passed / 4 failed (KI-01) / 41 skipped `update/v0.5.0` now: **1114 passed / 0 failed / 0 skipped**

### Design decisions

(sealing `loader.py` boundary, retiring `loaders/repository.py`, removing I/O from `Repository`, introducing `Author`/`Authors`/`Translator`/`Translators`) — see `DESIGN_DECISIONS.md`.

### Follow-ups (not in this PR)

- v0.6.x: self-hosted `go-httpbin` container for network tests (removes the last external-domain dependency in the test suite).